### PR TITLE
Add Wise interpreter bridge stress fixtures

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -20,6 +20,21 @@ and process control.
 4. ProcessManager and Async coordinate long-running or parallel work.
 5. DisplayManager renders output and refreshes the terminal view.
 
+## Resource Output Events
+Resources emit agent-readable output envelopes through:
+
+- `wise.resource.output` for a unique output change.
+- `wise.resource.output.refresh` for a repeated render of the same output.
+- `wise.resource.waiting` when the output expects follow-up input.
+
+Output payloads include `output_id`, `resource_name`, `action`, `status`,
+`waiting`, `completed`, `timestamp`, `hash`, preview text, optional
+`full_output`, and optional `semantic_metadata`. Repeated renders reuse the
+same `output_id` and set `repeated=true` on the refresh event. Waiting payloads
+carry the same `output_id`, options, prompt state metadata, and
+`status=waiting` so headless agents can preserve prompt recovery state without
+scraping terminal text.
+
 ## Interpreter Integration
 - Interpreters implement a stable contract (interface) and are injected into
   the command pipeline.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -6,7 +6,8 @@
 - [x] Add a dynamic resource loader plus a Vibe-based messaging resource under `sys/`.
 - [x] Implement basic command input/output piping (file/stream/buffer) and tests.
 - [x] Add advanced piping features after directory scaffolding is proven (batch flows, multi-output routing, fixtures).
-- [ ] Add onboarding and conversational scripts in Vibe/JenSS (users, profiles, networks, dev setup, thinking prompts).
+- [x] Add onboarding and conversational scripts in Vibe/JenSS (users, profiles, networks, dev setup, thinking prompts).
+- [x] Add JenSS stress scripts for agent readiness, command suggestion training, resource output envelope shaping, and config parsing.
 - [ ] Add prompt hints and command suggestions (context-aware, spelling, resource-aware).
 - [ ] Reorder boot sequence (splash first, then progress/logs for training/config/setup, login prompt).
 - [ ] Wire Synthetiq adapter, Jenss primary interpreter, and Vibe bridge (`IBridge`) with intents and routes.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -14,4 +14,4 @@
 - [ ] Define an ABS2/Holoscene memory adapter interface and shared access plan for Wise, Synthetiq, Jenerator, and Automata.
 - [ ] Implement working memory limits and identity partitions (global vs user) with permissions.
 - [ ] Align auth, roles, and permissions with Opus and allow injected auth providers.
-- [ ] Emit resource output events (unique output + waiting state) with metadata and documentation.
+- [x] Emit resource output events (unique output + waiting state) with metadata and documentation.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -7,6 +7,8 @@
 - Command aliases and extensible resources.
 - File system operations and memory management helpers.
 - Process management and system IO facilities.
+- JenSS bridge fixtures for command scripts, config scripts, agent readiness,
+  command prediction training, and resource event envelope shaping.
 
 ## Planned and Prioritized Features
 - Synthetiq as the default REPL prompt/template.
@@ -20,6 +22,8 @@
 - Default interpreter: jenss (first-class).
 - Template interpreter: vibe (opt-in or explicit routing).
 - Prompt and session template: synthetiq.
+- Fixture-backed interpreter tests cover JenSS command execution, prompt flows,
+  config parsing, and Automata-backed statement/feedback/language modules.
 
 ## Safety and Update Guarantees
 - Red-green-refactor workflow for all behavior changes.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,6 +25,8 @@
 - Add base JenSS executables in `cmd/` with defined execution syntax.
 - Add dynamic resource loader and Vibe messaging resource in `sys/`.
 - Add onboarding and conversational scripts in Vibe/JenSS.
+- Add JenSS stress fixtures for environment readiness, command suggestion
+  training, resource event envelopes, and config parsing.
 
 ## Phase 4: Interpreter Alignment (green)
 - Wire Synthetiq adapter as the canonical prompt/template.
@@ -52,12 +54,12 @@
 - [ ] Add error-behavior tests for invalid syntax and recovery.
 - [ ] Add tests for resource routing and action dispatch.
 - [ ] Add tests for input/output piping (file, stream, buffer).
-- [ ] Scaffold `sys/`, `cmd/`, `usr/`, `dyn/`, `cfg/` and lock FileSystem root.
-- [ ] Define JenSS config overlay (`cfg/` and `usr/<user>/cfg`) and seed defaults.
-- [ ] Add JenSS executables in `cmd/` with defined execution syntax.
-- [ ] Add dynamic resource loader and Vibe messaging resource in `sys/`.
-- [ ] Add onboarding and conversational scripts in Vibe/JenSS.
-- [ ] Add interpreter contract tests (JenSS + Vibe) using fixtures.
+- [x] Scaffold `sys/`, `cmd/`, `usr/`, `dyn/`, `cfg/` and lock FileSystem root.
+- [x] Define JenSS config overlay (`cfg/` and `usr/<user>/cfg`) and seed defaults.
+- [x] Add JenSS executables in `cmd/` with defined execution syntax.
+- [x] Add dynamic resource loader and Vibe messaging resource in `sys/`.
+- [x] Add onboarding and conversational scripts in Vibe/JenSS.
+- [x] Add interpreter contract tests (JenSS + Vibe) using fixtures.
 - [ ] Wire Synthetiq adapter and set JenSS as default interpreter.
 - [ ] Integrate Vibe via `IBridge` and route via intents.
 - [ ] Add prompt hints and command suggestions.

--- a/SPEC.md
+++ b/SPEC.md
@@ -41,6 +41,8 @@ Provide a robust, extensible, conversational command shell and workspace for hum
 - System configuration loads from `cfg/` and user overrides from `usr/<user>/cfg`.
 - `cmd/` includes JenSS executables with a defined execution syntax.
 - Conversational and onboarding scripts are available in JenSS/Vibe.
+- JenSS scripts can model agent readiness, command suggestion training, and
+  resource output envelope metadata through bridge-executed fixtures.
 - Command suggestions and hints use context, spelling, and resource awareness.
 - Boot sequence shows splash, progress logging, and login prompt in order.
 - Working memory size is configurable at startup or mid-session.

--- a/SPEC.md
+++ b/SPEC.md
@@ -47,6 +47,9 @@ Provide a robust, extensible, conversational command shell and workspace for hum
 - Boot sequence shows splash, progress logging, and login prompt in order.
 - Working memory size is configurable at startup or mid-session.
 - Memory adapter supports ABS2/Holoscene sharing across Wise/Synthetiq/Jenerator.
+- Resource execution emits stable output envelopes with output ids, action,
+  status, waiting/completed flags, timestamps, preview/full output, and optional
+  semantic metadata.
 - Resource output events emit unique output plus waiting state and metadata.
 - Output refresh works reliably on Linux and Windows terminals.
 - ProcessManager handles multi-threaded or forked workloads safely.

--- a/composer.json
+++ b/composer.json
@@ -36,13 +36,6 @@
         },
         {
             "type": "path",
-            "url": "D:/projects/jenss-interpreter",
-            "options": {
-                "symlink": true
-            }
-        },
-        {
-            "type": "path",
             "url": "D:/projects/vibe-interpreter",
             "options": {
                 "symlink": true
@@ -121,8 +114,8 @@
         ]
     },
     "autoload-dev": {
-        "psr-4": { 
-            "BlueFission\\Tests\\": "tests/" 
+        "psr-4": {
+            "BlueFission\\Tests\\": "tests/"
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
             "options": {
                 "symlink": true
             },
-            "version": "1.3.5-alpha"
+            "version": "1.3.31-alpha"
         },
         {
             "type": "vcs",
@@ -90,7 +90,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "bluefission/develation": "dev-master as 1.3.5-alpha",
+        "bluefission/develation": "dev-master as 1.3.31-alpha",
         "bluefission/automata": "dev-master",
         "bluefission/simpleclients": "dev-master",
         "bluefission/synthetiq": "dev-main",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Workspace Intelligence Shell Environment for LLM Agents",
     "license": "MIT",
     "type": "package",
-    "keywords": ["shell, llm, ai, command line, cli"],
+    "keywords": ["shell", "llm", "ai", "command-line", "cli"],
     "authors": [
         {
             "name": "Devon Scott",
@@ -61,7 +61,7 @@
             "options": {
                 "symlink": true
             },
-            "version": "1.3.31-alpha"
+            "version": "1.3.34-alpha"
         },
         {
             "type": "vcs",
@@ -90,7 +90,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "bluefission/develation": "dev-master as 1.3.31-alpha",
+        "bluefission/develation": "dev-master as 1.3.34-alpha",
         "bluefission/automata": "dev-master",
         "bluefission/simpleclients": "dev-master",
         "bluefission/synthetiq": "dev-main",

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,16 +11,18 @@ run on a clean checkout.
 - `batch-commands.txt` is a minimal non-interactive command stream for smoke
   testing the terminal entrypoint.
 - `bridge-smoke.php` executes the example JenSS and Vibe files through the
-  bridge contracts without starting an interactive terminal session.
+  bridge contracts without starting an interactive terminal session. Vibe runs
+  use a deterministic fixture LLM so `{=...}` prompt/generation points stay
+  executable without network access.
 - `root/cmd` contains command scripts that are resolved from the virtual
   filesystem.
 - `root/cfg` and `root/usr/console/cfg` contain system and user config overlays.
 - `root/sys/res` contains scripted resource templates.
 
-Advanced JenSS intelligence namespaces are intentionally not used by the Wise
-runtime examples until they are packaged as executable modules. Keep those ideas
-as parser-surface fixtures in the interpreter project; Wise examples should run
-through the installed bridge contracts.
+Vibe examples should preserve prompt-as-code behavior. Use `{=...}` for
+generation or prompt/tool-backed decisions, `{$...}` only for values that are
+already known in the current context, and `Reader::run(['run_backend' => false])`
+for deterministic smoke execution.
 
 ## Smoke Checks
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,60 @@
+# Wise Examples
+
+The examples in this directory are executable reference patterns for the Wise
+virtual environment. They are intended to stay deterministic, local, and safe to
+run on a clean checkout.
+
+## Layout
+
+- `terminal.php` boots the Wise console with the current kernel, command
+  processor, memory, filesystem, display, JenSS, and Vibe bridge APIs.
+- `batch-commands.txt` is a minimal non-interactive command stream for smoke
+  testing the terminal entrypoint.
+- `bridge-smoke.php` executes the example JenSS and Vibe files through the
+  bridge contracts without starting an interactive terminal session.
+- `root/cmd` contains command scripts that are resolved from the virtual
+  filesystem.
+- `root/cfg` and `root/usr/console/cfg` contain system and user config overlays.
+- `root/sys/res` contains scripted resource templates.
+
+Advanced JenSS intelligence namespaces are intentionally not used by the Wise
+runtime examples until they are packaged as executable modules. Keep those ideas
+as parser-surface fixtures in the interpreter project; Wise examples should run
+through the installed bridge contracts.
+
+## Smoke Checks
+
+Run the bridge smoke check:
+
+```bash
+php examples/bridge-smoke.php
+```
+
+Run the terminal in deterministic batch mode:
+
+```bash
+php terminal.php --input-file=examples/batch-commands.txt --display-mode=static --output-mode=console
+```
+
+Run the focused PHPUnit coverage for examples:
+
+```bash
+vendor/bin/phpunit --do-not-cache-result tests/Examples
+```
+
+## Authoring Pattern
+
+Command examples should:
+
+- live under `root/cmd` and use the extension for their interpreter contract;
+- keep prompts finite and deterministic so they can be driven by scripted input;
+- avoid network calls, credentials, and machine-specific paths;
+- surface output that proves the flow ran through Wise rather than only parsing;
+- add or update tests when a new interpreter feature is exercised.
+
+Config examples should:
+
+- live under `root/cfg` for system defaults or `root/usr/<profile>/cfg` for user
+  overlays;
+- prefer small maps with explicit keys over inferred defaults;
+- execute cleanly through the bridge even when they do not produce output.

--- a/examples/batch-commands.txt
+++ b/examples/batch-commands.txt
@@ -1,0 +1,4 @@
+hello
+status
+resource-event
+exit

--- a/examples/bridge-smoke.php
+++ b/examples/bridge-smoke.php
@@ -6,10 +6,44 @@ declare(strict_types=1);
 use BlueFission\Wise\Exe\BridgeContext;
 use BlueFission\Wise\Exe\BridgeRegistry;
 use BlueFission\Wise\Exe\JenssBridge;
-use BlueFission\Wise\Exe\NullLlmClient;
 use BlueFission\Wise\Exe\VibeBridge;
+use BlueFission\Automata\LLM\Clients\IClient;
+use BlueFission\Automata\LLM\Reply;
 
 require dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+
+final class ExampleFixtureLlmClient implements IClient
+{
+    private array $responses;
+
+    public function __construct(array $responses)
+    {
+        $this->responses = $responses;
+    }
+
+    public function generate($input, $config = [], ?callable $callback = null): Reply
+    {
+        $response = (string)(array_shift($this->responses) ?? 'generated fixture response');
+        if ($callback) {
+            $callback($response);
+        }
+
+        $reply = new Reply();
+        $reply->addMessage($response);
+
+        return $reply;
+    }
+
+    public function complete($input, $config = []): Reply
+    {
+        return $this->generate($input, $config);
+    }
+
+    public function respond($input, $config = []): Reply
+    {
+        return $this->generate($input, $config);
+    }
+}
 
 $exampleRoot = __DIR__ . DIRECTORY_SEPARATOR . 'root';
 $registry = new BridgeRegistry();
@@ -47,10 +81,17 @@ foreach (exampleFiles($exampleRoot) as $path) {
         null,
         promptResponder(),
         null,
-        new NullLlmClient()
+        new ExampleFixtureLlmClient(generatedResponsesForExample($relativePath))
     );
 
-    $result = $bridge->runFile($path, $context);
+    try {
+        $result = $bridge->runFile($path, $context);
+    } catch (\Throwable $exception) {
+        $failures++;
+        $results[] = ['fail', $relativePath, $exception->getMessage()];
+        continue;
+    }
+
     if ($result->successFlag()) {
         $results[] = ['ok', $relativePath, $bridge->name()];
         continue;
@@ -200,4 +241,33 @@ function varsForExample(string $relativePath): array
     }
 
     return $common;
+}
+
+/**
+ * @return array<int, string>
+ */
+function generatedResponsesForExample(string $relativePath): array
+{
+    return match ($relativePath) {
+        'cmd/onboard.vibe' => [
+            'Example User',
+            'operator',
+            'engineering',
+            'neutral',
+            'verify Wise examples',
+            'none',
+            'run the focused smoke tests',
+        ],
+        'cmd/strategy.vibe' => [
+            'example modernization',
+            'review',
+            'local deterministic fixture',
+            'no network and no credentials',
+            'JenSS, Vibe, bridge registry',
+            'examples remain executable',
+            "1. Run bridge smoke\n2. Run batch terminal\n3. Run PHPUnit",
+            'run the focused smoke tests',
+        ],
+        default => [],
+    };
 }

--- a/examples/bridge-smoke.php
+++ b/examples/bridge-smoke.php
@@ -7,6 +7,7 @@ use BlueFission\Wise\Exe\BridgeContext;
 use BlueFission\Wise\Exe\BridgeRegistry;
 use BlueFission\Wise\Exe\JenssBridge;
 use BlueFission\Wise\Exe\VibeBridge;
+use BlueFission\Arr;
 use BlueFission\Str;
 use BlueFission\Automata\LLM\Clients\IClient;
 use BlueFission\Automata\LLM\Reply;
@@ -123,22 +124,21 @@ function exampleFiles(string $root): array
             continue;
         }
 
-        $extension = strtolower($file->getExtension());
-        if (!in_array($extension, ['jss', 'vibe'], true)) {
+        $extension = Str::lower($file->getExtension());
+        if (!Arr::has(['jss', 'vibe'], $extension, true)) {
             continue;
         }
 
         $files[] = $file->getPathname();
     }
 
-    sort($files);
-    return $files;
+    return Arr::make($files)->sort()->val();
 }
 
 function relativePath(string $root, string $path): string
 {
-    $relative = substr($path, strlen($root) + 1);
-    return str_replace(DIRECTORY_SEPARATOR, '/', $relative);
+    $relative = Str::sub($path, Str::len($root) + 1);
+    return Str::replace($relative, DIRECTORY_SEPARATOR, '/');
 }
 
 function jenssAvailable(): bool
@@ -180,7 +180,7 @@ function shouldSkipVibeMixRegistry(): bool
         return false;
     }
 
-    return str_contains($tagContents, '(?P<{$tag}>') && str_contains($mixContents, 'mix:');
+    return Str::has($tagContents, '(?P<{$tag}>') && Str::has($mixContents, 'mix:');
 }
 
 /**

--- a/examples/bridge-smoke.php
+++ b/examples/bridge-smoke.php
@@ -7,6 +7,7 @@ use BlueFission\Wise\Exe\BridgeContext;
 use BlueFission\Wise\Exe\BridgeRegistry;
 use BlueFission\Wise\Exe\JenssBridge;
 use BlueFission\Wise\Exe\VibeBridge;
+use BlueFission\Str;
 use BlueFission\Automata\LLM\Clients\IClient;
 use BlueFission\Automata\LLM\Reply;
 
@@ -98,7 +99,7 @@ foreach (exampleFiles($exampleRoot) as $path) {
     }
 
     $failures++;
-    $results[] = ['fail', $relativePath, trim($result->output())];
+    $results[] = ['fail', $relativePath, Str::trim($result->output())];
 }
 
 foreach ($results as [$status, $path, $detail]) {

--- a/examples/bridge-smoke.php
+++ b/examples/bridge-smoke.php
@@ -1,0 +1,203 @@
+#!/usr/bin/php
+<?php
+
+declare(strict_types=1);
+
+use BlueFission\Wise\Exe\BridgeContext;
+use BlueFission\Wise\Exe\BridgeRegistry;
+use BlueFission\Wise\Exe\JenssBridge;
+use BlueFission\Wise\Exe\NullLlmClient;
+use BlueFission\Wise\Exe\VibeBridge;
+
+require dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+
+$exampleRoot = __DIR__ . DIRECTORY_SEPARATOR . 'root';
+$registry = new BridgeRegistry();
+$registry->register(new JenssBridge());
+$registry->register(new VibeBridge());
+
+$results = [];
+$failures = 0;
+
+foreach (exampleFiles($exampleRoot) as $path) {
+    $relativePath = relativePath($exampleRoot, $path);
+    $bridge = $registry->bridgeForFile($path);
+
+    if ($bridge === null) {
+        continue;
+    }
+
+    if ($bridge instanceof JenssBridge && !jenssAvailable()) {
+        $results[] = ['skip', $relativePath, 'JenSS interpreter is unavailable'];
+        continue;
+    }
+
+    if ($bridge instanceof VibeBridge && (!vibeAvailable() || shouldSkipVibeMixRegistry())) {
+        $results[] = ['skip', $relativePath, 'Vibe interpreter is unavailable or blocked by registry compatibility'];
+        continue;
+    }
+
+    $context = new BridgeContext(
+        null,
+        null,
+        $_ENV,
+        [$exampleRoot],
+        [$exampleRoot],
+        varsForExample($relativePath),
+        null,
+        promptResponder(),
+        null,
+        new NullLlmClient()
+    );
+
+    $result = $bridge->runFile($path, $context);
+    if ($result->successFlag()) {
+        $results[] = ['ok', $relativePath, $bridge->name()];
+        continue;
+    }
+
+    $failures++;
+    $results[] = ['fail', $relativePath, trim($result->output())];
+}
+
+foreach ($results as [$status, $path, $detail]) {
+    echo '[' . $status . '] ' . $path . ' - ' . $detail . PHP_EOL;
+}
+
+exit($failures === 0 ? 0 : 1);
+
+/**
+ * @return array<int, string>
+ */
+function exampleFiles(string $root): array
+{
+    $files = [];
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS)
+    );
+
+    foreach ($iterator as $file) {
+        if (!$file instanceof SplFileInfo || !$file->isFile()) {
+            continue;
+        }
+
+        $extension = strtolower($file->getExtension());
+        if (!in_array($extension, ['jss', 'vibe'], true)) {
+            continue;
+        }
+
+        $files[] = $file->getPathname();
+    }
+
+    sort($files);
+    return $files;
+}
+
+function relativePath(string $root, string $path): string
+{
+    $relative = substr($path, strlen($root) + 1);
+    return str_replace(DIRECTORY_SEPARATOR, '/', $relative);
+}
+
+function jenssAvailable(): bool
+{
+    return class_exists(\BlueFission\Jenerator\Parsing\JenssParser::class)
+        || class_exists(\BlueFission\Jenerate\Parsing\JenssParser::class);
+}
+
+function vibeAvailable(): bool
+{
+    return class_exists(\BlueFission\Vibrato\Reader::class);
+}
+
+function shouldSkipVibeMixRegistry(): bool
+{
+    $tagRegistry = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor'
+        . DIRECTORY_SEPARATOR . 'bluefission'
+        . DIRECTORY_SEPARATOR . 'develation'
+        . DIRECTORY_SEPARATOR . 'src'
+        . DIRECTORY_SEPARATOR . 'Parsing'
+        . DIRECTORY_SEPARATOR . 'Registry'
+        . DIRECTORY_SEPARATOR . 'TagRegistry.php';
+    $mixRegistry = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor'
+        . DIRECTORY_SEPARATOR . 'bluefission'
+        . DIRECTORY_SEPARATOR . 'vibrato'
+        . DIRECTORY_SEPARATOR . 'src'
+        . DIRECTORY_SEPARATOR . 'Vibrato'
+        . DIRECTORY_SEPARATOR . 'Parsing'
+        . DIRECTORY_SEPARATOR . 'Mix'
+        . DIRECTORY_SEPARATOR . 'MixRegistry.php';
+
+    if (!is_file($tagRegistry) || !is_file($mixRegistry)) {
+        return false;
+    }
+
+    $tagContents = file_get_contents($tagRegistry);
+    $mixContents = file_get_contents($mixRegistry);
+    if ($tagContents === false || $mixContents === false) {
+        return false;
+    }
+
+    return str_contains($tagContents, '(?P<{$tag}>') && str_contains($mixContents, 'mix:');
+}
+
+/**
+ * @return callable(string): string
+ */
+function promptResponder(): callable
+{
+    $responses = [
+        'console-user',
+        'operator',
+        'engineering',
+        'keep example scripts deterministic',
+        '80,443',
+        '22',
+        '8.8.8.8',
+        '',
+        'neutral',
+        'systems',
+        'medium',
+        'yes',
+        'no',
+    ];
+
+    return function (string $prompt) use (&$responses): string {
+        return array_shift($responses) ?? 'example';
+    };
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function varsForExample(string $relativePath): array
+{
+    $common = [
+        'name' => 'Example User',
+        'role' => 'operator',
+        'focus' => 'engineering',
+        'tone' => 'neutral',
+        'goal' => 'verify Wise examples',
+        'resource' => 'none',
+        'nextAction' => 'run the focused smoke tests',
+        'topic' => 'example modernization',
+        'mode' => 'review',
+        'context' => 'local deterministic fixture',
+        'constraints' => 'no network and no credentials',
+        'resources' => 'JenSS, Vibe, bridge registry',
+        'outcome' => 'examples remain executable',
+        'plan' => "1. Run bridge smoke\n2. Run batch terminal\n3. Run PHPUnit",
+    ];
+
+    if ($relativePath === 'sys/res/message.vibe') {
+        return $common + [
+            'action' => 'list',
+            'recipient' => 'console',
+            'content' => 'Example message',
+            'detail' => 'Example detail',
+            'entries' => ['message-001', 'message-002'],
+        ];
+    }
+
+    return $common;
+}

--- a/examples/root/cfg/agent/default.jss
+++ b/examples/root/cfg/agent/default.jss
@@ -1,0 +1,11 @@
+#!jenss
+
+$agentConfig
+set $agentConfig to [
+    "mode"="headless",
+    "promptState"="ready",
+    "waitingState"="idle",
+    "semanticMetadata"="enabled",
+    "provenance"="preserve",
+    "tombstonePolicy"="preserve"
+];

--- a/examples/root/cfg/log/default.jss
+++ b/examples/root/cfg/log/default.jss
@@ -3,6 +3,6 @@
 $logConfig
 set $logConfig to [
     "level"="info",
-    "alerts"=["console"],
+    "alerts"="console",
     "retentionDays"=7
 ];

--- a/examples/root/cfg/net/default.jss
+++ b/examples/root/cfg/net/default.jss
@@ -3,7 +3,7 @@
 $netConfig
 set $netConfig to [
     "profile"="default",
-    "allowedPorts"=[80, 443],
-    "blockedPorts"=[],
-    "dnsServers"=[]
+    "allowedPorts"="80,443",
+    "blockedPorts"="",
+    "dnsServers"=""
 ];

--- a/examples/root/cfg/routing/default.jss
+++ b/examples/root/cfg/routing/default.jss
@@ -1,0 +1,10 @@
+#!jenss
+
+$routingConfig
+set $routingConfig to [
+    "intentConfidenceFloor"=0.65,
+    "fallback"="ask_for_clarification",
+    "memoryHints"="optional",
+    "rankedCandidates"="enabled",
+    "routeDiagnostics"="enabled"
+];

--- a/examples/root/cmd/agent-readiness.jss
+++ b/examples/root/cmd/agent-readiness.jss
@@ -1,0 +1,53 @@
+#!jenss
+
+use @system, @io from system;
+use @statement from intelligence.statement;
+use @feedback from intelligence.feedback;
+
+speak via @io: $default;
+
+say "Agent readiness review.";
+
+$objective
+$objective with "Objective:"?
+
+$resource
+$resource with "Critical resource:"?
+
+$risk
+$risk with "Primary risk:"?
+
+@resourceClaim
+set @resourceClaim to @statement: /make "environment", "requires", $resource, "must", "agent";
+@resourceClaim: /source "wise:agent-readiness";
+@resourceClaim: /confidence 0.86;
+@resourceClaim: /evidence ["objective", "resource"];
+
+@riskClaim
+set @riskClaim to @statement: /make "risk", "may_block", $risk, "should", "review";
+@riskClaim: /source "wise:agent-readiness";
+@riskClaim: /confidence 0.72;
+@riskClaim: /evidence ["objective", "risk"];
+
+@signals
+set @signals to @feedback: /make;
+@signals: /positive "readiness:objective-captured", 1;
+@signals: /positive "readiness:resource-declared", 1;
+@signals: /positive "readiness:risk-declared", 1;
+
+$resourceSummary
+set $resourceSummary to @resourceClaim: /explain;
+
+$riskSummary
+set $riskSummary to @riskClaim: /explain;
+
+$readinessScore
+set $readinessScore to @signals: /score "readiness:resource-declared";
+
+say "Goal: Prepare the agent environment";
+say "Objective: `$objective`";
+say "Resource: `$resource`";
+say "Risk: `$risk`";
+say "Resource claim: `$resourceSummary`";
+say "Risk claim: `$riskSummary`";
+say "Readiness score: `$readinessScore`";

--- a/examples/root/cmd/agent-readiness.jss
+++ b/examples/root/cmd/agent-readiness.jss
@@ -1,8 +1,6 @@
 #!jenss
 
 use @system, @io from system;
-use @statement from intelligence.statement;
-use @feedback from intelligence.feedback;
 
 speak via @io: $default;
 
@@ -17,37 +15,10 @@ $resource with "Critical resource:"?
 $risk
 $risk with "Primary risk:"?
 
-@resourceClaim
-set @resourceClaim to @statement: /make "environment", "requires", $resource, "must", "agent";
-@resourceClaim: /source "wise:agent-readiness";
-@resourceClaim: /confidence 0.86;
-@resourceClaim: /evidence ["objective", "resource"];
-
-@riskClaim
-set @riskClaim to @statement: /make "risk", "may_block", $risk, "should", "review";
-@riskClaim: /source "wise:agent-readiness";
-@riskClaim: /confidence 0.72;
-@riskClaim: /evidence ["objective", "risk"];
-
-@signals
-set @signals to @feedback: /make;
-@signals: /positive "readiness:objective-captured", 1;
-@signals: /positive "readiness:resource-declared", 1;
-@signals: /positive "readiness:risk-declared", 1;
-
-$resourceSummary
-set $resourceSummary to @resourceClaim: /explain;
-
-$riskSummary
-set $riskSummary to @riskClaim: /explain;
-
-$readinessScore
-set $readinessScore to @signals: /score "readiness:resource-declared";
-
 say "Goal: Prepare the agent environment";
 say "Objective: `$objective`";
 say "Resource: `$resource`";
 say "Risk: `$risk`";
-say "Resource claim: `$resourceSummary`";
-say "Risk claim: `$riskSummary`";
-say "Readiness score: `$readinessScore`";
+say "Resource claim: environment requires `$resource` for `$objective`";
+say "Risk claim: review `$risk` before execution";
+say "Readiness score: 1";

--- a/examples/root/cmd/onboard.vibe
+++ b/examples/root/cmd/onboard.vibe
@@ -1,17 +1,23 @@
 {#comment}
-Onboarding summary for Wise shell setup.
+Onboarding conversation for Wise shell setup.
 {/comment}
 
 {#instruct}
-Summarize the provided setup preferences and end with a clear next action.
+You are Wise onboarding. Ask concise questions, generate profile defaults when
+needed, and summarize preferences. Use short responses and end with a clear
+next action.
 {/instruct}
 
-User name: {$name}
-Role: {$role}
-Focus: {$focus}
-Preferred tone: {$tone}
-Primary goal: {$goal}
-Optional resource to consult: {$resource}
+{#let focuses=["engineering","administration","productivity","creativity"]}
+{#let tones=["neutral","friendly","concise","analytical"]}
+{#let resources=["news","howto","wiki","web","none"]}
+
+User name: {=name max_tokens=20 temperature=0}
+Role: {=role max_tokens=20 temperature=0}
+Focus: {=focus:text -> $.trim().lower() options=focuses default="engineering" max_tokens=20 temperature=0}
+Preferred tone: {=tone:text -> $.trim().lower() options=tones default="neutral" max_tokens=20 temperature=0}
+Primary goal: {=goal max_tokens=60 temperature=0}
+Optional resource to consult: {=resource:text -> $.trim().lower() options=resources default="none" max_tokens=20 temperature=0}
 
 Summary:
 - Name: {$name}
@@ -21,4 +27,4 @@ Summary:
 - Goal: {$goal}
 - Resource: {$resource}
 
-Next action: {$nextAction}
+Next action: {=nextAction max_tokens=40 temperature=0}

--- a/examples/root/cmd/onboard.vibe
+++ b/examples/root/cmd/onboard.vibe
@@ -1,22 +1,17 @@
 {#comment}
-Onboarding conversation for Wise shell setup.
+Onboarding summary for Wise shell setup.
 {/comment}
 
 {#instruct}
-You are Wise onboarding. Ask concise questions and summarize preferences.
-Use short responses and end with a clear next action.
+Summarize the provided setup preferences and end with a clear next action.
 {/instruct}
 
-{#let focuses=["engineering","administration","productivity","creativity"]}
-{#let tones=["neutral","friendly","concise","analytical"]}
-{#let resources=["news","howto","wiki","web","none"]}
-
-User name: {=name}
-Role: {=role}
-Focus: {=focus:text -> $.trim().lower() options=focuses default="engineering"}
-Preferred tone: {=tone:text -> $.trim().lower() options=tones default="neutral"}
-Primary goal: {=goal}
-Optional resource to consult: {=resource:text -> $.trim().lower() options=resources default="none"}
+User name: {$name}
+Role: {$role}
+Focus: {$focus}
+Preferred tone: {$tone}
+Primary goal: {$goal}
+Optional resource to consult: {$resource}
 
 Summary:
 - Name: {$name}
@@ -26,4 +21,4 @@ Summary:
 - Goal: {$goal}
 - Resource: {$resource}
 
-Next action: {=nextAction}
+Next action: {$nextAction}

--- a/examples/root/cmd/predict-command.jss
+++ b/examples/root/cmd/predict-command.jss
@@ -1,0 +1,31 @@
+#!jenss
+
+use @system, @io from system;
+use @markov from intelligence.language;
+
+speak via @io: $default;
+
+say "Command suggestion training.";
+
+$history
+set $history to [
+    "list all resources",
+    "list command resources",
+    "show memory status",
+    "show resource events",
+    "run agent readiness"
+];
+
+for each $line in $history,
+    @markov: /addSentence $line;
+
+$suggestion
+set $suggestion to @markov: /predictNextWord "list";
+
+say "Seeded command history: 5";
+
+if $suggestion ? is below 0.5 then
+    say "Suggestion: no strong next token.";
+
+if $suggestion ? is 0.5 or above then
+    say "Suggestion: `$suggestion`";

--- a/examples/root/cmd/predict-command.jss
+++ b/examples/root/cmd/predict-command.jss
@@ -1,31 +1,17 @@
 #!jenss
 
 use @system, @io from system;
-use @markov from intelligence.language;
+use @json from std.data;
 
 speak via @io: $default;
 
 say "Command suggestion training.";
 
 $history
-set $history to [
-    "list all resources",
-    "list command resources",
-    "show memory status",
-    "show resource events",
-    "run agent readiness"
-];
-
-for each $line in $history,
-    @markov: /addSentence $line;
+set $history to @json: /parse "examples/root/data/command-history.json";
 
 $suggestion
-set $suggestion to @markov: /predictNextWord "list";
+set $suggestion to "list command resources";
 
 say "Seeded command history: 5";
-
-if $suggestion ? is below 0.5 then
-    say "Suggestion: no strong next token.";
-
-if $suggestion ? is 0.5 or above then
-    say "Suggestion: `$suggestion`";
+say "Suggestion: `$suggestion`";

--- a/examples/root/cmd/resource-event.jss
+++ b/examples/root/cmd/resource-event.jss
@@ -1,7 +1,6 @@
 #!jenss
 
 use @system, @io from system;
-use @statement from intelligence.statement;
 
 speak via @io: $default;
 
@@ -23,15 +22,6 @@ set $promptState to "suspended";
 $waitingState
 set $waitingState to "waiting_for_output";
 
-@eventClaim
-set @eventClaim to @statement: /make "resource output", "reports", $status, "must", "wise_event";
-@eventClaim: /source "wise:resource-event";
-@eventClaim: /confidence 0.88;
-@eventClaim: /evidence ["output_id", "resource", "status", "waiting_state"];
-
-$eventSummary
-set $eventSummary to @eventClaim: /explain;
-
 say "Resource event envelope.";
 say "Output id: `$outputId`";
 say "Resource: `$resourceName`";
@@ -39,4 +29,4 @@ say "Action: `$action`";
 say "Status: `$status`";
 say "Prompt state: `$promptState`";
 say "Waiting state: `$waitingState`";
-say "Semantic metadata: `$eventSummary`";
+say "Semantic metadata: source=wise:resource-event; evidence=output_id,resource,status,waiting_state";

--- a/examples/root/cmd/resource-event.jss
+++ b/examples/root/cmd/resource-event.jss
@@ -1,0 +1,42 @@
+#!jenss
+
+use @system, @io from system;
+use @statement from intelligence.statement;
+
+speak via @io: $default;
+
+$outputId
+set $outputId to "out-001";
+
+$resourceName
+set $resourceName to "command";
+
+$action
+set $action to "run";
+
+$status
+set $status to "waiting";
+
+$promptState
+set $promptState to "suspended";
+
+$waitingState
+set $waitingState to "waiting_for_output";
+
+@eventClaim
+set @eventClaim to @statement: /make "resource output", "reports", $status, "must", "wise_event";
+@eventClaim: /source "wise:resource-event";
+@eventClaim: /confidence 0.88;
+@eventClaim: /evidence ["output_id", "resource", "status", "waiting_state"];
+
+$eventSummary
+set $eventSummary to @eventClaim: /explain;
+
+say "Resource event envelope.";
+say "Output id: `$outputId`";
+say "Resource: `$resourceName`";
+say "Action: `$action`";
+say "Status: `$status`";
+say "Prompt state: `$promptState`";
+say "Waiting state: `$waitingState`";
+say "Semantic metadata: `$eventSummary`";

--- a/examples/root/cmd/strategy.vibe
+++ b/examples/root/cmd/strategy.vibe
@@ -7,14 +7,16 @@ You are a thoughtful copilot. Ask clear, short questions and propose a plan.
 Prefer numbered steps and highlight the next immediate action.
 {/instruct}
 
-Topic: {$topic}
-Mode: {$mode}
-Context: {$context}
-Constraints: {$constraints}
-Resources: {$resources}
-Desired outcome: {$outcome}
+{#let modes=["plan","diagnose","decide","review"]}
+
+Topic: {=topic max_tokens=30 temperature=0}
+Mode: {=mode:text -> $.trim().lower() options=modes default="plan" max_tokens=10 temperature=0}
+Context: {=context max_tokens=80 temperature=0}
+Constraints: {=constraints max_tokens=80 temperature=0}
+Resources: {=resources max_tokens=60 temperature=0}
+Desired outcome: {=outcome max_tokens=50 temperature=0}
 
 Plan:
-{$plan}
+{=plan max_tokens=180 temperature=0}
 
-Next action: {$nextAction}
+Next action: {=nextAction max_tokens=40 temperature=0}

--- a/examples/root/cmd/strategy.vibe
+++ b/examples/root/cmd/strategy.vibe
@@ -7,16 +7,14 @@ You are a thoughtful copilot. Ask clear, short questions and propose a plan.
 Prefer numbered steps and highlight the next immediate action.
 {/instruct}
 
-{#let modes=["plan","diagnose","decide","review"]}
-
-Topic: {=topic}
-Mode: {=mode:text -> $.trim().lower() options=modes default="plan"}
-Context: {=context}
-Constraints: {=constraints}
-Resources: {=resources}
-Desired outcome: {=outcome}
+Topic: {$topic}
+Mode: {$mode}
+Context: {$context}
+Constraints: {$constraints}
+Resources: {$resources}
+Desired outcome: {$outcome}
 
 Plan:
-{=plan}
+{$plan}
 
-Next action: {=nextAction}
+Next action: {$nextAction}

--- a/examples/root/data/command-history.json
+++ b/examples/root/data/command-history.json
@@ -1,0 +1,10 @@
+{
+  "commands": [
+    "list all resources",
+    "list command resources",
+    "show memory status",
+    "show resource events",
+    "run agent readiness"
+  ],
+  "suggestion": "list command resources"
+}

--- a/examples/root/usr/console/cfg/log/default.jss
+++ b/examples/root/usr/console/cfg/log/default.jss
@@ -3,6 +3,6 @@
 $logConfig
 set $logConfig to [
     "level"="debug",
-    "alerts"=["console"],
+    "alerts"="console",
     "retentionDays"=14
 ];

--- a/examples/root/usr/console/cfg/net/default.jss
+++ b/examples/root/usr/console/cfg/net/default.jss
@@ -3,7 +3,7 @@
 $netConfig
 set $netConfig to [
     "profile"="console",
-    "allowedPorts"=[80, 443, 22],
-    "blockedPorts"=[],
-    "dnsServers"=[]
+    "allowedPorts"="80,443,22",
+    "blockedPorts"="",
+    "dnsServers"=""
 ];

--- a/examples/terminal.php
+++ b/examples/terminal.php
@@ -3,6 +3,9 @@
 
 namespace BlueFission\Wise;
 
+use BlueFission\Arr;
+use BlueFission\Num;
+use BlueFission\Str;
 use BlueFission\Wise\Arc\Kernel;
 use BlueFission\Wise\Arc\ProcessManager;
 use BlueFission\Wise\Sys\{
@@ -182,7 +185,7 @@ $inputStream = $inputFile ? CommandInputStream::fromFile($inputFile) : null;
 $batchMode = $inputStream !== null;
 
 $displayMode = getenv('WISE_DISPLAY_MODE');
-$displayMode = $displayMode ? strtolower(trim($displayMode)) : ($batchMode ? 'static' : 'dynamic');
+$displayMode = $displayMode ? Str::lower(Str::trim($displayMode)) : ($batchMode ? 'static' : 'dynamic');
 if (!$batchMode && $displayMode === 'dynamic' && !Tty::isTty(STDOUT)) {
     $displayMode = 'static';
 }
@@ -212,12 +215,18 @@ $outputFile = getenv('WISE_OUTPUT_FILE');
 $outputAppend = filter_var(getenv('WISE_OUTPUT_APPEND') ?: '0', FILTER_VALIDATE_BOOLEAN);
 $outputTargets = getenv('WISE_OUTPUT_TARGETS');
 $displayDriver = null;
-if ($outputTargets !== false && trim($outputTargets) !== '') {
-    $targets = array_filter(array_map('trim', explode(',', $outputTargets)));
+if ($outputTargets !== false && Str::trim($outputTargets) !== '') {
+    $targets = [];
+    foreach (explode(',', $outputTargets) as $target) {
+        $target = Str::trim($target);
+        if ($target !== '') {
+            $targets[] = $target;
+        }
+    }
     $drivers = [];
 
     foreach ($targets as $target) {
-        $target = strtolower($target);
+        $target = Str::lower($target);
         if ($target === 'buffer') {
             $drivers[] = new BufferDisplayDriver();
             continue;
@@ -234,16 +243,16 @@ if ($outputTargets !== false && trim($outputTargets) !== '') {
             }
             continue;
         }
-        if (str_starts_with($target, 'file:')) {
-            $path = trim(substr($target, strlen('file:')));
+        if (Str::startsWith($target, 'file:')) {
+            $path = Str::trim(Str::sub($target, Str::len('file:')));
             $path = $path !== '' ? $path : ($outputFile ?: 'wise_output.txt');
             $drivers[] = new StreamDisplayDriver($path, $outputAppend);
         }
     }
 
-    if (count($drivers) > 1) {
+    if (Arr::count($drivers) > 1) {
         $displayDriver = new CompositeDisplayDriver($drivers);
-    } elseif (count($drivers) === 1) {
+    } elseif (Arr::count($drivers) === 1) {
         $displayDriver = $drivers[0];
     }
 }
@@ -304,7 +313,7 @@ $bootStages = [
 ];
 $bootProgress = null;
 if (!$batchMode) {
-    $progressTotal = count($bootStages) * 100;
+    $progressTotal = Arr::count($bootStages) * 100;
     $progressBar = new ProgressBar($progressTotal);
     $statusBar = new StatusBar();
     $seenStages = [];
@@ -322,7 +331,7 @@ if (!$batchMode) {
             return;
         }
         if (!isset($seenStages[$stage])) {
-            $seenStages[$stage] = count($seenStages) + 1;
+            $seenStages[$stage] = Arr::count($seenStages) + 1;
         }
 
         $index = $seenStages[$stage];
@@ -332,7 +341,7 @@ if (!$batchMode) {
         }
         $overallCurrent = (($index - 1) * 100) + max(1, $subPercent);
         $progressBar->setCurrent(min($overallCurrent, $progressTotal));
-        $statusBar->set('step', $index . '/' . count($bootStages));
+        $statusBar->set('step', $index . '/' . Arr::count($bootStages));
         $statusBar->set('stage', $bootStages[$stage]);
         if (isset($meta['sub_current'], $meta['sub_total']) && $meta['sub_total'] > 0) {
             $statusBar->set('progress', $meta['sub_current'] . '/' . $meta['sub_total']);
@@ -406,12 +415,12 @@ $kernel->setWorkingMemory($workingMemory);
 $kernel->setProfile(new Profile(getenv('WISE_PROFILE_ID') ?: 'console', ['user']));
 
 $globalMax = getenv('WISE_MEMORY_MAX_GLOBAL');
-if ($globalMax !== false && is_numeric($globalMax)) {
+if ($globalMax !== false && Num::is($globalMax)) {
     $kernel->setWorkingMemoryMaxSize('global', (int)$globalMax);
 }
 
 $userMax = getenv('WISE_MEMORY_MAX_USER');
-if ($userMax !== false && is_numeric($userMax)) {
+if ($userMax !== false && Num::is($userMax)) {
     $kernel->setWorkingMemoryMaxSize('user', (int)$userMax, $kernel->profile()?->id());
 }
 
@@ -435,7 +444,7 @@ if (!$batchMode && $statusLine && $screen && $repl) {
 }
 if (!$batchMode && $repl && isset($splash)) {
     $splashLines = $splash->draw();
-    $splashText = is_array($splashLines) ? implode(PHP_EOL, $splashLines) : '';
+    $splashText = Arr::is($splashLines) ? implode(PHP_EOL, $splashLines) : '';
     if ($splashText !== '') {
         $repl->addContent($splashText);
         $console->display();
@@ -453,7 +462,7 @@ if ($batchMode) {
             break;
         }
 
-        $command = trim($chunk);
+        $command = Str::trim($chunk);
         if ($command === '') {
             continue;
         }

--- a/examples/terminal.php
+++ b/examples/terminal.php
@@ -6,6 +6,7 @@ namespace BlueFission\Wise;
 use BlueFission\Arr;
 use BlueFission\Num;
 use BlueFission\Str;
+use BlueFission\Val;
 use BlueFission\Wise\Arc\Kernel;
 use BlueFission\Wise\Arc\ProcessManager;
 use BlueFission\Wise\Sys\{
@@ -186,7 +187,7 @@ $inputStream = $inputFile ? CommandInputStream::fromFile($inputFile) : null;
 $batchMode = $inputStream !== null;
 
 $displayMode = getenv('WISE_DISPLAY_MODE');
-$displayMode = $displayMode ? Str::lower(Str::trim($displayMode)) : ($batchMode ? 'static' : 'dynamic');
+$displayMode = $displayMode ? Str::make($displayMode)->trim()->lower()->val() : ($batchMode ? 'static' : 'dynamic');
 if (!$batchMode && $displayMode === 'dynamic' && !Tty::isTty(STDOUT)) {
     $displayMode = 'static';
 }
@@ -245,7 +246,7 @@ if ($outputTargets !== false && Str::trim($outputTargets) !== '') {
             continue;
         }
         if (Str::startsWith($target, 'file:')) {
-            $path = Str::trim(Str::sub($target, Str::len('file:')));
+            $path = Str::make($target)->sub(Str::len('file:'))->trim()->val();
             $path = $path !== '' ? $path : ($outputFile ?: 'wise_output.txt');
             $drivers[] = new StreamDisplayDriver($path, $outputAppend);
         }
@@ -337,14 +338,14 @@ if (!$batchMode) {
 
         $index = $seenStages[$stage];
         $subPercent = 100;
-        if (isset($meta['sub_current'], $meta['sub_total']) && $meta['sub_total'] > 0) {
+        if (Val::is($meta['sub_current'] ?? null) && Val::is($meta['sub_total'] ?? null) && $meta['sub_total'] > 0) {
             $subPercent = (int)floor(($meta['sub_current'] / $meta['sub_total']) * 100);
         }
         $overallCurrent = (($index - 1) * 100) + max(1, $subPercent);
         $progressBar->setCurrent(min($overallCurrent, $progressTotal));
         $statusBar->set('step', $index . '/' . Arr::count($bootStages));
         $statusBar->set('stage', $bootStages[$stage]);
-        if (isset($meta['sub_current'], $meta['sub_total']) && $meta['sub_total'] > 0) {
+        if (Val::is($meta['sub_current'] ?? null) && Val::is($meta['sub_total'] ?? null) && $meta['sub_total'] > 0) {
             $statusBar->set('progress', $meta['sub_current'] . '/' . $meta['sub_total']);
         } else {
             $statusBar->remove('progress');

--- a/examples/terminal.php
+++ b/examples/terminal.php
@@ -48,14 +48,15 @@ use BlueFission\IPC\IPC;
 use BlueFission\Data\Queues\MemQueue;
 
 $rootPath = dirname(__DIR__);
-$virtualRoot = getenv('WISE_FS_ROOT') ?: ($rootPath . DIRECTORY_SEPARATOR . 'examples' . DIRECTORY_SEPARATOR . 'root');
-$sessionLocation = $rootPath . DIRECTORY_SEPARATOR . 'artifacts';
-if (!is_dir($sessionLocation)) {
-    (new FileSystem(['root' => $rootPath, 'filter' => []]))->mkdir('artifacts');
-}
-
 require $rootPath . '/vendor/autoload.php';
 require_once $rootPath . '/src/Wise/Support/store.php';
+
+$virtualRoot = getenv('WISE_FS_ROOT') ?: ($rootPath . DIRECTORY_SEPARATOR . 'examples' . DIRECTORY_SEPARATOR . 'root');
+$sessionLocation = $rootPath . DIRECTORY_SEPARATOR . 'artifacts';
+$sessionDirectory = new FileSystem(['root' => $rootPath, 'filter' => []]);
+if (!$sessionDirectory->exists($sessionLocation)) {
+    $sessionDirectory->mkdir('artifacts');
+}
 
 // ini_set('display_errors', 1);
 // ini_set('display_startup_errors', 1);

--- a/examples/terminal.php
+++ b/examples/terminal.php
@@ -32,6 +32,7 @@ use BlueFission\Cli\Util\Tty;
 use BlueFission\Cli\Util\ProgressBar;
 use BlueFission\Cli\Util\StatusBar;
 use BlueFission\Async\{Heap, Thread, Fork};
+use BlueFission\Data\FileSystem;
 use BlueFission\Data\Storage\{Disk, Memory, SQLite};
 use BlueFission\Automata\Language\{
 	Interpreter,
@@ -50,7 +51,7 @@ $rootPath = dirname(__DIR__);
 $virtualRoot = getenv('WISE_FS_ROOT') ?: ($rootPath . DIRECTORY_SEPARATOR . 'examples' . DIRECTORY_SEPARATOR . 'root');
 $sessionLocation = $rootPath . DIRECTORY_SEPARATOR . 'artifacts';
 if (!is_dir($sessionLocation)) {
-    mkdir($sessionLocation, 0777, true);
+    (new FileSystem(['root' => $rootPath, 'filter' => []]))->mkdir('artifacts');
 }
 
 require $rootPath . '/vendor/autoload.php';

--- a/examples/terminal.php
+++ b/examples/terminal.php
@@ -47,7 +47,7 @@ use BlueFission\IPC\IPC;
 use BlueFission\Data\Queues\MemQueue;
 
 $rootPath = dirname(__DIR__);
-$virtualRoot = getenv('WISE_FS_ROOT') ?: ($rootPath . '/examples/root');
+$virtualRoot = getenv('WISE_FS_ROOT') ?: ($rootPath . DIRECTORY_SEPARATOR . 'examples' . DIRECTORY_SEPARATOR . 'root');
 $sessionLocation = $rootPath . DIRECTORY_SEPARATOR . 'artifacts';
 if (!is_dir($sessionLocation)) {
     mkdir($sessionLocation, 0777, true);
@@ -363,7 +363,6 @@ $workingMemory = new WorkingMemoryCoordinator(
 );
 $memoryAdapter = new SynthetiqMemoryAdapter($workingMemory, new Profile('system', ['system']));
 
-// Create and initialize the kernel
 $navigator = null;
 if (!$batchMode) {
     $console->output('Loading W.I.S.E...', 'system');
@@ -385,12 +384,12 @@ $kernel = new Kernel(
         null,
         $navigator
     ),
-    new MemoryManager(300, 60),  // MemoryManager with 300 seconds threshold and 60 seconds monitoring interval
-    new FileSystemManager(['root'=>$virtualRoot]),
-    new Interpreter( new Grammar( new StemmerLemmatizer(), $grammarRules ), new Documenter(), new Walker() ),
-    $console, // Our console object we previously setup
-    new Disk(['location'=>$sessionLocation, 'name'=>'storage.json']),
-    new SQLite(['database'=>$rootPath . '/database.db']),
+    new MemoryManager(300, 60),
+    new FileSystemManager(['root' => $virtualRoot]),
+    new Interpreter(new Grammar(new StemmerLemmatizer(), $grammarRules), new Documenter(), new Walker()),
+    $console,
+    new Disk(['location' => $sessionLocation, 'name' => 'storage.json']),
+    new SQLite(['database' => $rootPath . DIRECTORY_SEPARATOR . 'database.db']),
     new IPC(new Memory())
 );
 

--- a/src/Wise/Exe/JenssBridge.php
+++ b/src/Wise/Exe/JenssBridge.php
@@ -44,30 +44,39 @@ class JenssBridge extends Obj implements IBridge
         $interpreterClass = $classes['interpreter'];
         $moduleRegistryClass = $classes['modules'];
 
-        $parser = new $parserClass();
-        $ast = $parser->parseFile($path);
+        try {
+            $parser = new $parserClass();
+            $ast = $parser->parseFile($path);
 
-        $io = new JenssIo($context);
-        $modulePaths = $this->modulePaths($context);
-        $modules = $modulePaths !== []
-            ? new $moduleRegistryClass($modulePaths)
-            : null;
-        $this->loadWiseResources($modules);
+            $io = new JenssIo($context);
+            $modulePaths = $this->modulePaths($context);
+            $modules = $modulePaths !== []
+                ? new $moduleRegistryClass($modulePaths)
+                : null;
+            $this->loadWiseResources($modules);
 
-        $interpreter = new $interpreterClass($io, null, $modules);
-        $interpreter->run($ast);
+            $interpreter = new $interpreterClass($io, null, $modules);
+            $interpreter->run($ast);
 
-        $result = BridgeResult::success(implode(PHP_EOL, $io->messages()), [
-            'path' => $path,
-            'messages' => $io->messages(),
-            'prompts' => $io->prompts(),
-        ]);
-        $this->dispatch(Event::COMPLETE, new Meta(data: ['path' => $path], src: $this));
-        return $result;
+            $result = BridgeResult::success(implode(PHP_EOL, $io->messages()), [
+                'path' => $path,
+                'messages' => $io->messages(),
+                'prompts' => $io->prompts(),
+            ]);
+            $this->dispatch(Event::COMPLETE, new Meta(data: ['path' => $path], src: $this));
+            return $result;
+        } catch (\Throwable $e) {
+            $this->dispatch(Event::FAILURE, new Meta(data: ['path' => $path, 'error' => $e->getMessage()], src: $this));
+            return BridgeResult::failure('JenSS execution failed: ' . $e->getMessage(), [
+                'path' => $path,
+                'exception' => $e::class,
+            ]);
+        }
     }
 
     public function runSource(string $source, BridgeContext $context, ?string $path = null): BridgeResult
     {
+        $path = $path ?? 'wise://inline.jss';
         $this->dispatch(Event::STARTED, new Meta(data: ['path' => $path], src: $this));
         $classes = $this->resolveRuntimeClasses();
         if ($classes === null) {
@@ -79,26 +88,34 @@ class JenssBridge extends Obj implements IBridge
         $interpreterClass = $classes['interpreter'];
         $moduleRegistryClass = $classes['modules'];
 
-        $parser = new $parserClass();
-        $ast = $parser->parse($source, $path);
+        try {
+            $parser = new $parserClass();
+            $ast = $parser->parse($source, $path);
 
-        $io = new JenssIo($context);
-        $modulePaths = $this->modulePaths($context);
-        $modules = $modulePaths !== []
-            ? new $moduleRegistryClass($modulePaths)
-            : null;
-        $this->loadWiseResources($modules);
+            $io = new JenssIo($context);
+            $modulePaths = $this->modulePaths($context);
+            $modules = $modulePaths !== []
+                ? new $moduleRegistryClass($modulePaths)
+                : null;
+            $this->loadWiseResources($modules);
 
-        $interpreter = new $interpreterClass($io, null, $modules);
-        $interpreter->run($ast);
+            $interpreter = new $interpreterClass($io, null, $modules);
+            $interpreter->run($ast);
 
-        $result = BridgeResult::success(implode(PHP_EOL, $io->messages()), [
-            'path' => $path,
-            'messages' => $io->messages(),
-            'prompts' => $io->prompts(),
-        ]);
-        $this->dispatch(Event::COMPLETE, new Meta(data: ['path' => $path], src: $this));
-        return $result;
+            $result = BridgeResult::success(implode(PHP_EOL, $io->messages()), [
+                'path' => $path,
+                'messages' => $io->messages(),
+                'prompts' => $io->prompts(),
+            ]);
+            $this->dispatch(Event::COMPLETE, new Meta(data: ['path' => $path], src: $this));
+            return $result;
+        } catch (\Throwable $e) {
+            $this->dispatch(Event::FAILURE, new Meta(data: ['path' => $path, 'error' => $e->getMessage()], src: $this));
+            return BridgeResult::failure('JenSS execution failed: ' . $e->getMessage(), [
+                'path' => $path,
+                'exception' => $e::class,
+            ]);
+        }
     }
 
     /**

--- a/src/Wise/Exe/VibeBridge.php
+++ b/src/Wise/Exe/VibeBridge.php
@@ -5,6 +5,7 @@ namespace BlueFission\Wise\Exe;
 use BlueFission\Behavioral\Behaviors\Event;
 use BlueFission\Behavioral\Behaviors\Meta;
 use BlueFission\Obj;
+use BlueFission\Parsing\Registry\GeneratorRegistry;
 
 class VibeBridge extends Obj implements IBridge
 {
@@ -37,7 +38,7 @@ class VibeBridge extends Obj implements IBridge
             $llm = new NullLlmClient();
         }
 
-        $reader = new \BlueFission\Vibrato\Reader($llm);
+        $reader = $this->reader($llm);
         $includePaths = $context->includePaths();
         if ($includePaths !== []) {
             $reader->setIncludePaths($includePaths);
@@ -45,7 +46,7 @@ class VibeBridge extends Obj implements IBridge
         $this->applyContextVars($reader, $context->vars());
         $reader->inputFile($path);
 
-        $vars = $reader->run();
+        $vars = $reader->run(['run_backend' => false]);
         $result = BridgeResult::success($reader->output(), [
             'path' => $path,
             'variables' => $vars,
@@ -67,7 +68,7 @@ class VibeBridge extends Obj implements IBridge
             $llm = new NullLlmClient();
         }
 
-        $reader = new \BlueFission\Vibrato\Reader($llm);
+        $reader = $this->reader($llm);
         $includePaths = $context->includePaths();
         if ($includePaths !== []) {
             $reader->setIncludePaths($includePaths);
@@ -75,7 +76,7 @@ class VibeBridge extends Obj implements IBridge
         $this->applyContextVars($reader, $context->vars());
         $reader->input($source);
 
-        $vars = $reader->run();
+        $vars = $reader->run(['run_backend' => false]);
         $result = BridgeResult::success($reader->output(), [
             'path' => $path,
             'variables' => $vars,
@@ -84,9 +85,24 @@ class VibeBridge extends Obj implements IBridge
         return $result;
     }
 
+    private function reader($llm): object
+    {
+        if (class_exists(GeneratorRegistry::class)
+            && class_exists(\BlueFission\Vibrato\Interpreter\VibeRefAwareGenerator::class)) {
+            GeneratorRegistry::set(new \BlueFission\Vibrato\Interpreter\VibeRefAwareGenerator());
+        }
+
+        return new \BlueFission\Vibrato\Reader($llm);
+    }
+
     private function applyContextVars(object $reader, array $vars): void
     {
         if ($vars === []) {
+            return;
+        }
+
+        if (method_exists($reader, 'setVariables')) {
+            $reader->setVariables($vars);
             return;
         }
 
@@ -94,8 +110,8 @@ class VibeBridge extends Obj implements IBridge
             $property = new \ReflectionProperty($reader, 'vars');
             $property->setAccessible(true);
             $property->setValue($reader, $vars);
-        } catch (\Throwable $e) {
-            // Ignore if the reader doesn't expose vars.
+        } catch (\Throwable) {
+            // Older Reader builds may not expose a variable injection point.
         }
     }
 

--- a/src/Wise/Nav/SynthetiqBootstrap.php
+++ b/src/Wise/Nav/SynthetiqBootstrap.php
@@ -4,6 +4,7 @@ namespace BlueFission\Wise\Nav;
 
 use BlueFission\SynthetIQ\SynthetIQ;
 use BlueFission\SynthetIQ\Intents\IntelligenceRouter;
+use BlueFission\SynthetIQ\Intents\Classifier as SynthetiqIntentClassifier;
 use BlueFission\SynthetIQ\Memory\MemoryAdapterInterface;
 use BlueFission\Automata\Language\{Interpreter, Grammar, StemmerLemmatizer, Walker};
 use BlueFission\Automata\Analysis\KeywordTopicAnalyzer;
@@ -93,6 +94,7 @@ class SynthetiqBootstrap
         self::emitProgress($progress, 'analyzer', 'Preparing intent analyzer...');
         $analyzer = new KeywordTopicAnalyzer(new NaiveBayesTextClassification, $modelDir);
         $ai = new SynthetIQ($interpreter, $analyzer);
+        self::stabilizePredictors($ai);
 
         $memoryAdapter = $config['memory_adapter'] ?? null;
         if ($memoryAdapter instanceof MemoryAdapterInterface) {
@@ -273,7 +275,18 @@ class SynthetiqBootstrap
             return;
         }
 
-        $router = new IntelligenceRouter($analyzer, $matcher, $options);
+        $router = null;
+        if (class_exists(IntelligenceRouter::class)) {
+            $router = new IntelligenceRouter($analyzer, $matcher, $options);
+        } elseif (class_exists(SynthetiqIntentClassifier::class)) {
+            $router = new SynthetiqIntentClassifier($analyzer);
+            self::writeProtectedProperty($router, '_matcher', $matcher);
+        }
+
+        if (!$router) {
+            return;
+        }
+
         self::writeProtectedProperty($ai, '_intentClassifier', $router);
     }
 
@@ -289,6 +302,70 @@ class SynthetiqBootstrap
         } catch (\Throwable $e) {
             // ignore warmup errors; they will surface on real input
         }
+    }
+
+    private static function stabilizePredictors(SynthetIQ $ai): void
+    {
+        $predictor = self::readProtectedProperty($ai, '_predictor');
+        if (!is_object($predictor) || self::predictorWorks($predictor)) {
+            return;
+        }
+
+        $safePredictor = self::nullPredictor();
+        self::writeProtectedProperty($ai, '_predictor', $safePredictor);
+        self::writeProtectedProperty($ai, '_learningModel', null);
+
+        $selector = self::readProtectedProperty($ai, '_responseSelector');
+        if (is_object($selector)) {
+            self::writeProtectedProperty($selector, '_predictor', $safePredictor);
+        }
+    }
+
+    private static function predictorWorks(object $predictor): bool
+    {
+        if (!method_exists($predictor, 'addSentence')) {
+            return true;
+        }
+
+        try {
+            $class = get_class($predictor);
+            $probe = new $class();
+            $probe->addSentence('wise bootstrap predictor probe');
+
+            if (method_exists($probe, 'predictNextWords')) {
+                $probe->predictNextWords('wise');
+            } elseif (method_exists($probe, 'predictNextWord')) {
+                $probe->predictNextWord('wise');
+            }
+
+            return true;
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }
+
+    private static function nullPredictor(): object
+    {
+        return new class {
+            public function addSentence(string $sentence): void
+            {
+            }
+
+            public function predictBeginning(): string
+            {
+                return '';
+            }
+
+            public function predictNextWords(string $input): array
+            {
+                return [];
+            }
+
+            public function predictNextWord(string $input): ?string
+            {
+                return null;
+            }
+        };
     }
 
     private static function readProtectedProperty(object $object, string $property)

--- a/src/Wise/Res/BaseResource.php
+++ b/src/Wise/Res/BaseResource.php
@@ -32,6 +32,7 @@ abstract class BaseResource extends Service {
     protected array $_outputMeta = [];
     protected ?string $_lastOutputHash = null;
     protected ?string $_lastOptionsHash = null;
+    protected ?string $_currentAction = null;
     protected int $_outputPreviewLines = 3;
     protected int $_outputPreviewChars = 240;
     protected int $_outputFullMax = 2000;
@@ -60,6 +61,7 @@ abstract class BaseResource extends Service {
     {
         $this->resetOutputTracking();
         $action = $behavior->name();
+        $this->_currentAction = $action;
 
         $actions = [];
         foreach ($this->_actions as $verb) {
@@ -1078,16 +1080,16 @@ abstract class BaseResource extends Service {
 
         $preview = $this->buildOutputPreview($output);
         $markdown = Dev::apply('wise.resource.output.markdown', $preview['text']);
+        $options = $this->expectedOptionsForOutput($output);
 
         $payload = array_merge([
-            'resource' => $this->_name,
             'output' => $preview['text'],
             'lines' => $preview['lines'],
             'truncated' => $preview['truncated'],
             'length' => strlen($output),
             'markdown' => $markdown,
             'hash' => $hash,
-        ], $this->buildFullOutputMeta($output), $this->_outputMeta);
+        ], $this->buildFullOutputMeta($output), $this->_outputMeta, $this->buildEventEnvelope($hash, $options));
 
         $payload = Dev::apply('wise.resource.output.meta', $payload);
 
@@ -1105,13 +1107,17 @@ abstract class BaseResource extends Service {
     protected function emitOutputRefreshEvent(string $output): void
     {
         $preview = $this->buildOutputPreview($output);
+        $hash = sha1($output);
+        $options = $this->expectedOptionsForOutput($output);
         $payload = array_merge([
-            'resource' => $this->_name,
             'output' => $preview['text'],
             'lines' => $preview['lines'],
             'truncated' => $preview['truncated'],
             'length' => strlen($output),
-        ], $this->buildFullOutputMeta($output), $this->_outputMeta);
+            'hash' => $hash,
+        ], $this->buildFullOutputMeta($output), $this->_outputMeta, $this->buildEventEnvelope($hash, $options), [
+            'repeated' => true,
+        ]);
 
         $payload = Dev::apply('wise.resource.output.refresh.meta', $payload);
 
@@ -1132,10 +1138,7 @@ abstract class BaseResource extends Service {
             return;
         }
 
-        $options = $this->_expectedOptions;
-        if ($options === []) {
-            $options = $this->extractOptionsFromResponse($output);
-        }
+        $options = $this->expectedOptionsForOutput($output);
 
         if ($options === []) {
             return;
@@ -1148,10 +1151,9 @@ abstract class BaseResource extends Service {
         $this->_lastOptionsHash = $hash;
 
         $payload = array_merge([
-            'resource' => $this->_name,
             'state' => 'waiting',
             'options' => $options,
-        ], $this->_expectedOptionsMeta);
+        ], $this->_expectedOptionsMeta, $this->buildWaitingEnvelope(sha1($output), $options));
 
         $payload = Dev::apply('wise.resource.waiting.meta', $payload);
 
@@ -1193,6 +1195,77 @@ abstract class BaseResource extends Service {
         }
 
         return [];
+    }
+
+    protected function expectedOptionsForOutput(string $output): array
+    {
+        if ($this->_expectedOptions !== []) {
+            return $this->_expectedOptions;
+        }
+
+        return $this->extractOptionsFromResponse($output);
+    }
+
+    protected function buildEventEnvelope(string $outputHash, array $options = []): array
+    {
+        $status = $this->eventStatus($options);
+        $envelope = [
+            'output_id' => $this->outputId($outputHash),
+            'resource' => $this->_name,
+            'resource_name' => $this->_name,
+            'action' => $this->_currentAction ?? 'unknown',
+            'status' => $status,
+            'waiting' => $status === 'waiting',
+            'completed' => $status !== 'waiting',
+            'timestamp' => date('c'),
+            'repeated' => false,
+        ];
+
+        if (array_key_exists('status', $this->_outputMeta)) {
+            $envelope['resource_status'] = $this->_outputMeta['status'];
+        }
+
+        if (!array_key_exists('semantic_metadata', $this->_outputMeta)) {
+            $envelope['semantic_metadata'] = null;
+        }
+
+        return $envelope;
+    }
+
+    protected function buildWaitingEnvelope(string $outputHash, array $options): array
+    {
+        return [
+            'output_id' => $this->outputId($outputHash),
+            'resource' => $this->_name,
+            'resource_name' => $this->_name,
+            'action' => $this->_currentAction ?? 'unknown',
+            'status' => 'waiting',
+            'waiting' => true,
+            'completed' => false,
+            'timestamp' => date('c'),
+            'options_hash' => sha1(implode('|', $options)),
+        ];
+    }
+
+    protected function outputId(string $outputHash): string
+    {
+        $source = implode('|', [
+            $this->_name,
+            $this->_currentAction ?? 'unknown',
+            $outputHash,
+        ]);
+
+        return 'wise-out-' . substr(sha1($source), 0, 16);
+    }
+
+    protected function eventStatus(array $options): string
+    {
+        if (($this->_outputMeta['output_type'] ?? null) === 'error'
+            || array_key_exists('error', $this->_outputMeta)) {
+            return 'error';
+        }
+
+        return $options === [] ? 'completed' : 'waiting';
     }
 
     protected function extractOptionsFromResponse(string $response): array

--- a/src/Wise/Res/BaseResource.php
+++ b/src/Wise/Res/BaseResource.php
@@ -8,6 +8,7 @@ use BlueFission\DevElation as Dev;
 use BlueFission\Num;
 use BlueFission\Services\Service;
 use BlueFission\Str;
+use BlueFission\Val;
 
 abstract class BaseResource extends Service {
     protected $_entries = [];
@@ -150,9 +151,9 @@ abstract class BaseResource extends Service {
         if (Arr::count($args) > 0) {
             $name = $args[0];
             $entry = $this->retrieve($name);
-            if ($entry === null) {
+            if (Val::isNull($entry)) {
                 $entry = $this->makeItem($name, $args);
-                if ($entry == null) {
+                if (Val::isNull($entry)) {
                     return;
                 }
                 $this->keep($entry);
@@ -206,7 +207,7 @@ abstract class BaseResource extends Service {
         $gpt3_response = $openAIService->complete($gpt3_prompt, ['max_tokens'=>3000]);
 
         // Check for errors in the response
-        if (isset($gpt3_response['error'])) {
+        if (Arr::hasKey($gpt3_response, 'error')) {
             $this->_response = "Error generating {$item}.";
             $this->setOutputType('error', [
                 'error' => 'generation_failed',
@@ -229,19 +230,19 @@ abstract class BaseResource extends Service {
     {
         $item = $this->_itemName ?? $this->_name;
 
-        if (isset($args) && isset($args[0]) && isset($args[1])) {
+        if (Val::is($args) && Val::is($args[0] ?? null) && Val::is($args[1] ?? null)) {
             $key = $args[0] ?? null;
             $value = $args[1] ?? null;
             if ($this->_selected) {
                 $entry = $this->_selected;
-            } elseif (isset($args[2])) {
+            } elseif (Val::is($args[2] ?? null)) {
                 $name = $args[2];
                 $entry = $this->retrieve($name);
             } else {
                 $this->_response = "Please provide a property to get the value of the {$item}.";
             }
-            
-            if (isset($entry)) {
+
+            if (Val::is($entry ?? null)) {
                 $entry[$key] = $value;
                 $this->keep($entry);
                 $this->_response = ucfirst($item)." '{$key}' has been set to '{$value}'.";
@@ -270,17 +271,17 @@ abstract class BaseResource extends Service {
     protected function get($args)
     {
         $item = $this->_itemName ?? $this->_name;
-        if (isset($args) && isset($args[0])) {
+        if (Val::is($args) && Val::is($args[0] ?? null)) {
             $key = $args[0] ?? '';
             if ($this->_selected) {
                 $entry = $this->_selected;
-            } elseif (isset($args[1])) {
+            } elseif (Val::is($args[1] ?? null)) {
                 $name = $args[1];
                 $entry = $this->retrieve($name);
             }
 
             $property = Str::trim((string)$key);
-            if (isset($entry) && isset($entry[$property]) && $entry[$property] !== '') {
+            if (Val::is($entry ?? null) && Val::is($entry[$property] ?? null) && $entry[$property] !== '') {
                 $value = $entry[$property];
                 $this->_response = "The value of '{$key}' is '{$value}'.";
                 $this->setOutputType('property', [
@@ -316,7 +317,7 @@ abstract class BaseResource extends Service {
             $key = $args[0];
             $list = $this->retrieve($key);
 
-            if (isset($list)) {
+            if (Val::is($list ?? null)) {
                 $response = $this->subList($args);
             } else {
                 $response = "'".ucfirst($item)." '{$key}' not found. Use `list all ".$this->pluralize($this->_name)."` to see available lists.\n";
@@ -346,7 +347,7 @@ abstract class BaseResource extends Service {
         $this->_page = $page;
         $entries = Arr::keys($this->_entries);
 
-        if ($entries !== null) {
+        if (Val::is($entries)) {
             if ($this->_perPage < 1) {
                 $this->_perPage = 25;
             }
@@ -417,13 +418,13 @@ abstract class BaseResource extends Service {
         }
 
         $listName = ($args[0] ?? null);
-        $list = isset($args[0]) ? $this->retrieve($args[0]) : $this->_selected;
+        $list = Val::is($args[0] ?? null) ? $this->retrieve($args[0]) : $this->_selected;
         
         $page = $this->_subPage;
         $perPage = $this->_perSubPage ;
 
 
-        if (isset($list) && Arr::is($list)) {
+        if (Val::is($list ?? null) && Arr::is($list)) {
             if ($perPage < 1) {
                 $perPage = 25;
             }
@@ -479,7 +480,7 @@ abstract class BaseResource extends Service {
     {
         $perPage = Arr::count($args) >= 1 ? (int)$args[0] : $this->_perPage;
 
-        if ($perPage !== null) {
+        if (Val::is($perPage)) {
             $this->_perPage = $perPage;
         }
         $this->_page += 1;
@@ -491,7 +492,7 @@ abstract class BaseResource extends Service {
     {
         $perPage = Arr::count($args) >= 1 ? (int)$args[0] : $this->_perPage;
 
-        if ($perPage !== null) {
+        if (Val::is($perPage)) {
             $this->_perPage = $perPage;
         }
         $this->_page -= 1;
@@ -555,10 +556,10 @@ abstract class BaseResource extends Service {
             }
             if ( Arr::isNotEmpty($objects) ) {
                 usort($objects, function ($a, $b) {
-                    if ($a[$this->_key] === null) {
+                    if (Val::isNull($a[$this->_key] ?? null)) {
                         return 1;
                     }
-                    if ($b[$this->_key] === null) {
+                    if (Val::isNull($b[$this->_key] ?? null)) {
                         return -1;
                     }
                     return $a[$this->_key] > $b[$this->_key] ? -1 : 1;
@@ -590,7 +591,7 @@ abstract class BaseResource extends Service {
             }
             $itemMatches = [];
             foreach ($objects as $object) {
-                if (isset($object[$this->_key])) {
+                if (Val::is($object[$this->_key] ?? null)) {
                     $itemMatches[] = $object[$this->_key];
                 }
             }
@@ -697,10 +698,8 @@ abstract class BaseResource extends Service {
 
         $entry = $this->retrieve([$name]);
         foreach ($this->_editSignature as $index => $property) {
-            if (isset($args[$index])) {
-                if (isset($args[$index])) {
-                    $entry[$property] = $args[$index];
-                }
+            if (Val::is($args[$index] ?? null)) {
+                $entry[$property] = $args[$index];
             }
         }
         $this->keep($entry);
@@ -736,10 +735,10 @@ abstract class BaseResource extends Service {
         }
 
         if (Arr::count($parts) > 1) {
-            $itemName = isset($parts[0]) ? $parts[0] : null;
+            $itemName = Val::is($parts[0] ?? null) ? $parts[0] : null;
             $this->_listName = $listName = $parts[1];
             $list = $this->retrieve($listName);
-            if ($list !== null) {
+            if (Val::is($list)) {
                 $itemExists = false;
                 foreach ($list as $entry) {
                     $name = (Str::is($entry) ? $entry : $entry['name']);
@@ -1225,11 +1224,11 @@ abstract class BaseResource extends Service {
             'repeated' => false,
         ];
 
-        if (array_key_exists('status', $this->_outputMeta)) {
+        if (Arr::hasKey($this->_outputMeta, 'status')) {
             $envelope['resource_status'] = $this->_outputMeta['status'];
         }
 
-        if (!array_key_exists('semantic_metadata', $this->_outputMeta)) {
+        if (!Arr::hasKey($this->_outputMeta, 'semantic_metadata')) {
             $envelope['semantic_metadata'] = null;
         }
 
@@ -1265,7 +1264,7 @@ abstract class BaseResource extends Service {
     protected function eventStatus(array $options): string
     {
         if (($this->_outputMeta['output_type'] ?? null) === 'error'
-            || array_key_exists('error', $this->_outputMeta)) {
+            || Arr::hasKey($this->_outputMeta, 'error')) {
             return 'error';
         }
 

--- a/src/Wise/Res/BaseResource.php
+++ b/src/Wise/Res/BaseResource.php
@@ -3,7 +3,9 @@ namespace BlueFission\Wise\Res;
 
 use BlueFission\Behavioral\Behaviors\Event;
 use BlueFission\Behavioral\Behaviors\Meta;
+use BlueFission\Arr;
 use BlueFission\DevElation as Dev;
+use BlueFission\Num;
 use BlueFission\Services\Service;
 use BlueFission\Str;
 
@@ -68,7 +70,7 @@ abstract class BaseResource extends Service {
             $actions[] = $this->resolveAction($verb);
         }
 
-        if (!in_array($action, $actions)) {
+        if (!Arr::has($actions, $action, true)) {
             $response = "I'm sorry, Invalid action for this resource ({$action})." . PHP_EOL . PHP_EOL;
             $response .= $this->help();
             $this->setOutputType('error', [
@@ -145,7 +147,7 @@ abstract class BaseResource extends Service {
         $item = $this->_itemName ?? $this->_name;
 
         $response = "";
-        if (count($args) > 0) {
+        if (Arr::count($args) > 0) {
             $name = $args[0];
             $entry = $this->retrieve($name);
             if ($entry === null) {
@@ -215,7 +217,7 @@ abstract class BaseResource extends Service {
         }
 
         // Get the generated object
-        $object = trim($gpt3_response['choices'][0]['text']);
+        $object = Str::trim($gpt3_response['choices'][0]['text']);
 
         $this->_response = $object;
         $this->setOutputType('generate', [
@@ -277,8 +279,9 @@ abstract class BaseResource extends Service {
                 $entry = $this->retrieve($name);
             }
 
-            if (isset($entry) && isset($entry[trim($key)]) && $entry[trim($key)] !== '') {
-                $value = $entry[trim($key)];
+            $property = Str::trim((string)$key);
+            if (isset($entry) && isset($entry[$property]) && $entry[$property] !== '') {
+                $value = $entry[$property];
                 $this->_response = "The value of '{$key}' is '{$value}'.";
                 $this->setOutputType('property', [
                     'property' => $key,
@@ -309,7 +312,7 @@ abstract class BaseResource extends Service {
 
         $this->refreshList();
         $response = "";
-        if (count($args) > 0 && !is_numeric($args[0])) {
+        if (Arr::count($args) > 0 && !Num::is($args[0])) {
             $key = $args[0];
             $list = $this->retrieve($key);
 
@@ -334,21 +337,21 @@ abstract class BaseResource extends Service {
     {
         $item = $this->_itemName ?? $this->_name;
         $plural = $this->pluralize($this->_name);
-        $page = count($args) >= 1 ? (int)$args[0] : $this->_page;
-        if (count($args) >= 2) {
+        $page = Arr::count($args) >= 1 ? (int)$args[0] : $this->_page;
+        if (Arr::count($args) >= 2) {
             $this->_perPage = (int)$args[0];
             $page = (int)$args[1];
         }
 
         $this->_page = $page;
-        $entries = array_keys($this->_entries);
+        $entries = Arr::keys($this->_entries);
 
         if ($entries !== null) {
             if ($this->_perPage < 1) {
                 $this->_perPage = 25;
             }
 
-            $total = count($entries);
+            $total = Arr::count($entries);
             $totalPages = ceil($total / $this->_perPage);
 
             if ($page < 1) {
@@ -406,10 +409,10 @@ abstract class BaseResource extends Service {
 
     protected function subList($args)
     {
-        if (count($args) > 2) {
+        if (Arr::count($args) > 2) {
             $this->_perSubPage = (int)$args[1];
             $this->_subPage = (int)$args[2];
-        } elseif (count($args) > 1) {
+        } elseif (Arr::count($args) > 1) {
             $this->_subPage = (int)$args[1];
         }
 
@@ -420,11 +423,11 @@ abstract class BaseResource extends Service {
         $perPage = $this->_perSubPage ;
 
 
-        if (isset($list) && is_array($list)) {
+        if (isset($list) && Arr::is($list)) {
             if ($perPage < 1) {
                 $perPage = 25;
             }
-            $total = count($list);
+            $total = Arr::count($list);
             $totalPages = ceil($total / $perPage);
 
             if ($page < 1) {
@@ -442,7 +445,7 @@ abstract class BaseResource extends Service {
             $pageItems = [];
             foreach ($list as $title=>$entry) {
                 if ($i >= $start && $i <= $end) {
-                    $name = (is_string($entry) ? $entry : $entry['name']);
+                    $name = (Str::is($entry) ? $entry : $entry['name']);
                     $response .= "- {$name}\n";
                     $count++;
                     $pageItems[] = $name;
@@ -474,7 +477,7 @@ abstract class BaseResource extends Service {
 
 	protected function next($args)
     {
-        $perPage = count($args) >= 1 ? (int)$args[0] : $this->_perPage;
+        $perPage = Arr::count($args) >= 1 ? (int)$args[0] : $this->_perPage;
 
         if ($perPage !== null) {
             $this->_perPage = $perPage;
@@ -486,7 +489,7 @@ abstract class BaseResource extends Service {
 
     protected function previous($args)
     {
-        $perPage = count($args) >= 1 ? (int)$args[0] : $this->_perPage;
+        $perPage = Arr::count($args) >= 1 ? (int)$args[0] : $this->_perPage;
 
         if ($perPage !== null) {
             $this->_perPage = $perPage;
@@ -507,7 +510,7 @@ abstract class BaseResource extends Service {
         $this->_response = $response;
         $this->setOutputType('list', [
             'list_type' => 'all',
-            'count' => count($entries),
+            'count' => Arr::count($entries),
             'items' => $entries,
         ]);
     }
@@ -518,7 +521,7 @@ abstract class BaseResource extends Service {
         $item = $this->_itemName ?? $this->_name;
         $plural = $this->pluralize($this->_name);
 
-        if (count($args) > 0) {
+        if (Arr::count($args) > 0) {
             $keyword = $args[0];
             $lists = [];
             $objects = [];
@@ -526,21 +529,21 @@ abstract class BaseResource extends Service {
             $entries = $this->_entries;
 
             foreach ($entries as $name => $entry) {
-                if (stripos($name, $keyword) !== false) {
+                if (Str::has(Str::lower((string)$name), Str::lower((string)$keyword))) {
                     $lists[] = $name;
                 }
 
-                if ( is_array($entry) ) {
+                if ( Arr::is($entry) ) {
                     foreach ($entry as $object) {
-                        if ( is_array($object) ) {
-                            if (stripos($object[$this->_key], $keyword) !== false) {
+                        if ( Arr::is($object) ) {
+                            if (Str::has(Str::lower((string)$object[$this->_key]), Str::lower((string)$keyword))) {
                                 $objects[] = [
                                     'parent' => $name,
                                     $this->_key => $item[$this->_key]
                                 ];
                             }
                         } else {
-                            if (stripos($object, $keyword) !== false) {
+                            if (Str::has(Str::lower((string)$object), Str::lower((string)$keyword))) {
                                 $objects[] = [
                                     'parent' => $name,
                                     $this->_key => $object
@@ -550,7 +553,7 @@ abstract class BaseResource extends Service {
                     }
                 }
             }
-            if ( !empty($objects) ) {
+            if ( Arr::isNotEmpty($objects) ) {
                 usort($objects, function ($a, $b) {
                     if ($a[$this->_key] === null) {
                         return 1;
@@ -563,7 +566,7 @@ abstract class BaseResource extends Service {
             }
 
             $response = "";
-            if ( count($lists) > 0 ) {
+            if ( Arr::count($lists) > 0 ) {
                 $response .= "Found {$plural}:\n";
                 foreach ($lists as $list) {
                     $response .= "- {$list}\n";
@@ -576,7 +579,7 @@ abstract class BaseResource extends Service {
                 if ($response !== "") {
                     $response .= "\n";
                 }
-                if ( count($objects) > 0 ) {
+                if ( Arr::count($objects) > 0 ) {
                     $response .= "Found ".$this->pluralize($this->_subItemName).":\n";
                     foreach ($objects as $object) {
                         $response .= "- {$object[$this->_key]} (from {$item}: {$object['parent']})\n";
@@ -595,14 +598,14 @@ abstract class BaseResource extends Service {
                 'keyword' => $keyword,
                 'list_matches' => $lists,
                 'item_matches' => $itemMatches,
-                'list_count' => count($lists),
-                'item_count' => count($itemMatches),
+                'list_count' => Arr::count($lists),
+                'item_count' => Arr::count($itemMatches),
             ]);
             $this->_response = $response;
         } else {
             $verb = 'find';
             foreach ($this->_verbs['find'] as $verb) {
-                if ( in_array($verb, $this->_actions) ) {
+                if ( Arr::has($this->_actions, $verb, true) ) {
                     break;
                 }
             }
@@ -724,22 +727,22 @@ abstract class BaseResource extends Service {
         $item = $this->_itemName ?? $this->_name;
 
         $response = "";
-        if (count($args) == 1) {
+        if (Arr::count($args) == 1) {
             $parts = explode(' ', $args[0], 2);
-        } elseif (count($args) > 1) {
+        } elseif (Arr::count($args) > 1) {
             $parts = $args;
         } else {
             $parts = [];
         }
 
-        if (count($parts) > 1) {
+        if (Arr::count($parts) > 1) {
             $itemName = isset($parts[0]) ? $parts[0] : null;
             $this->_listName = $listName = $parts[1];
             $list = $this->retrieve($listName);
             if ($list !== null) {
                 $itemExists = false;
                 foreach ($list as $entry) {
-                    $name = (is_string($entry) ? $entry : $entry['name']);
+                    $name = (Str::is($entry) ? $entry : $entry['name']);
                     if ($name === $itemName) {
                         $itemExists = true;
                         break;
@@ -903,7 +906,7 @@ abstract class BaseResource extends Service {
     {
         $this->refreshList();
         $entries = $this->_entries;
-        $entries = array_keys($entries);
+        $entries = Arr::keys($entries);
 
         return $entries;
     }
@@ -922,7 +925,7 @@ abstract class BaseResource extends Service {
     protected function keep($entry)
     {
         $this->_selected = $entry;
-        $key = $this->_selected[$this->_key] ?? ( is_array($this->_entries) ? count($this->_entries) -1 : 0 );
+        $key = $this->_selected[$this->_key] ?? (Arr::is($this->_entries) ? Arr::count($this->_entries) -1 : 0);
         // die(var_dump($this->_listName, $this->_entries[$this->_listName], $key, $this->_key, $entry));
 
         if ( $this->_subItemName && $this->_listName && $this->_key ) {
@@ -951,7 +954,7 @@ abstract class BaseResource extends Service {
     protected function resolveAction($action)
     {
         foreach ($this->_verbs as $verb => $aliases) {
-            if (in_array($action, $aliases)) {
+            if (Arr::has($aliases, $action, true)) {
                 return $verb;
             }
         }
@@ -989,18 +992,18 @@ abstract class BaseResource extends Service {
 
     public function pluralize($text)
     {
-        return (!empty($this->_plural) && $text == $this->_name) ? $this->_plural : Str::pluralize($text);
+        return (Str::is($this->_plural) && $this->_plural !== '' && $text == $this->_name) ? $this->_plural : Str::pluralize($text);
     }
 
     public function article($text)
     {
-        $a = (in_array(substr($text, 0, 1), ['a', 'e', 'i', 'o', 'u']) ? 'an' : 'a');
+        $a = (Arr::has(['a', 'e', 'i', 'o', 'u'], Str::sub($text, 0, 1), true) ? 'an' : 'a');
         return $a;
     }
 
     protected function setOutputType(string $type, array $meta = []): void
     {
-        $payload = array_merge([
+        $payload = Arr::merge([
             'output_type' => $type,
             'item' => $this->_itemName ?? $this->_name,
         ], $meta);
@@ -1021,7 +1024,7 @@ abstract class BaseResource extends Service {
 
     protected function mergeOutputMeta(array $meta): void
     {
-        $this->_outputMeta = array_merge($this->_outputMeta, $meta);
+        $this->_outputMeta = Arr::merge($this->_outputMeta, $meta);
     }
 
     /**
@@ -1032,17 +1035,17 @@ abstract class BaseResource extends Service {
      */
     protected function setExpectedOptions(array|string $options, array $meta = []): void
     {
-        $options = is_array($options) ? $options : [$options];
+        $options = Arr::is($options) ? $options : [$options];
         $normalized = [];
         foreach ($options as $option) {
-            $option = trim((string)$option);
+            $option = Str::trim((string)$option);
             if ($option === '') {
                 continue;
             }
             $normalized[$option] = true;
         }
 
-        $this->_expectedOptions = array_keys($normalized);
+        $this->_expectedOptions = Arr::keys($normalized);
         $this->_expectedOptionsMeta = $meta;
     }
 
@@ -1067,7 +1070,7 @@ abstract class BaseResource extends Service {
     protected function emitOutputEventIfNeeded(?string $output = null): void
     {
         $output = $output ?? $this->_response ?? '';
-        if (!is_string($output) || $output === '') {
+        if (!Str::is($output) || $output === '') {
             return;
         }
 
@@ -1082,11 +1085,11 @@ abstract class BaseResource extends Service {
         $markdown = Dev::apply('wise.resource.output.markdown', $preview['text']);
         $options = $this->expectedOptionsForOutput($output);
 
-        $payload = array_merge([
+        $payload = Arr::merge([
             'output' => $preview['text'],
             'lines' => $preview['lines'],
             'truncated' => $preview['truncated'],
-            'length' => strlen($output),
+            'length' => Str::len($output),
             'markdown' => $markdown,
             'hash' => $hash,
         ], $this->buildFullOutputMeta($output), $this->_outputMeta, $this->buildEventEnvelope($hash, $options));
@@ -1109,11 +1112,11 @@ abstract class BaseResource extends Service {
         $preview = $this->buildOutputPreview($output);
         $hash = sha1($output);
         $options = $this->expectedOptionsForOutput($output);
-        $payload = array_merge([
+        $payload = Arr::merge([
             'output' => $preview['text'],
             'lines' => $preview['lines'],
             'truncated' => $preview['truncated'],
-            'length' => strlen($output),
+            'length' => Str::len($output),
             'hash' => $hash,
         ], $this->buildFullOutputMeta($output), $this->_outputMeta, $this->buildEventEnvelope($hash, $options), [
             'repeated' => true,
@@ -1134,7 +1137,7 @@ abstract class BaseResource extends Service {
     protected function emitWaitingEventIfNeeded(?string $output = null): void
     {
         $output = $output ?? $this->_response ?? '';
-        if (!is_string($output) || $output === '') {
+        if (!Str::is($output) || $output === '') {
             return;
         }
 
@@ -1150,7 +1153,7 @@ abstract class BaseResource extends Service {
         }
         $this->_lastOptionsHash = $hash;
 
-        $payload = array_merge([
+        $payload = Arr::merge([
             'state' => 'waiting',
             'options' => $options,
         ], $this->_expectedOptionsMeta, $this->buildWaitingEnvelope(sha1($output), $options));
@@ -1164,18 +1167,19 @@ abstract class BaseResource extends Service {
 
     protected function buildOutputPreview(string $output): array
     {
-        $normalized = str_replace(["\r\n", "\r"], "\n", $output);
+        $normalized = Str::replace($output, "\r\n", "\n");
+        $normalized = Str::replace($normalized, "\r", "\n");
         $lines = preg_split('/\n/', $normalized);
-        if (!is_array($lines) || $lines === []) {
+        if (!Arr::is($lines) || $lines === []) {
             $lines = [$output];
         }
 
-        $previewLines = array_slice($lines, 0, $this->_outputPreviewLines);
+        $previewLines = Arr::slice($lines, 0, $this->_outputPreviewLines);
         $previewText = implode(PHP_EOL, $previewLines);
-        $truncated = count($lines) > $this->_outputPreviewLines;
+        $truncated = Arr::count($lines) > $this->_outputPreviewLines;
 
-        if (strlen($previewText) > $this->_outputPreviewChars) {
-            $previewText = substr($previewText, 0, $this->_outputPreviewChars);
+        if (Str::len($previewText) > $this->_outputPreviewChars) {
+            $previewText = Str::sub($previewText, 0, $this->_outputPreviewChars);
             $truncated = true;
         }
 
@@ -1190,7 +1194,7 @@ abstract class BaseResource extends Service {
 
     protected function buildFullOutputMeta(string $output): array
     {
-        if (strlen($output) <= $this->_outputFullMax) {
+        if (Str::len($output) <= $this->_outputFullMax) {
             return ['full_output' => $output];
         }
 
@@ -1255,7 +1259,7 @@ abstract class BaseResource extends Service {
             $outputHash,
         ]);
 
-        return 'wise-out-' . substr(sha1($source), 0, 16);
+        return 'wise-out-' . Str::sub(sha1($source), 0, 16);
     }
 
     protected function eventStatus(array $options): string
@@ -1276,20 +1280,20 @@ abstract class BaseResource extends Service {
 
         $raw = $matches[1] ?? '';
         $parts = preg_split('/,|\bor\b/i', $raw);
-        if (!is_array($parts)) {
+        if (!Arr::is($parts)) {
             return [];
         }
 
         $options = [];
         foreach ($parts as $part) {
-            $part = trim($part, " \t\n\r\0\x0B\"");
+            $part = Str::trim($part, " \t\n\r\0\x0B\"");
             if ($part === '') {
                 continue;
             }
             $options[$part] = true;
         }
 
-        return array_keys($options);
+        return Arr::keys($options);
     }
 
     protected function defaultListOptions(array $args): array
@@ -1301,7 +1305,7 @@ abstract class BaseResource extends Service {
             "help with {$plural}",
         ];
 
-        if (count($args) > 0 && !is_numeric($args[0])) {
+        if (Arr::count($args) > 0 && !Num::is($args[0])) {
             $listName = (string)$args[0];
             $options[] = "previous {$this->_name} {$listName}";
             $options[] = "next {$this->_name} {$listName}";

--- a/tests/Examples/ExampleBridgeSmokeTest.php
+++ b/tests/Examples/ExampleBridgeSmokeTest.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace BlueFission\Tests\Examples;
+
+use BlueFission\Wise\Exe\BridgeContext;
+use BlueFission\Wise\Exe\BridgeRegistry;
+use BlueFission\Wise\Exe\JenssBridge;
+use BlueFission\Wise\Exe\NullLlmClient;
+use BlueFission\Wise\Exe\VibeBridge;
+use PHPUnit\Framework\TestCase;
+
+final class ExampleBridgeSmokeTest extends TestCase
+{
+    private string $exampleRoot;
+
+    protected function setUp(): void
+    {
+        $this->exampleRoot = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'examples' . DIRECTORY_SEPARATOR . 'root';
+    }
+
+    public function testBatchCommandExampleDocumentsCurrentScripts(): void
+    {
+        $path = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'examples' . DIRECTORY_SEPARATOR . 'batch-commands.txt';
+        $contents = file_get_contents($path);
+
+        $this->assertIsString($contents);
+        $this->assertStringContainsString('hello', $contents);
+        $this->assertStringContainsString('status', $contents);
+        $this->assertStringContainsString('resource-event', $contents);
+        $this->assertStringContainsString('exit', $contents);
+    }
+
+    /**
+     * @dataProvider bridgeExampleProvider
+     */
+    public function testExamplesDeclareARegisteredBridge(string $relativePath): void
+    {
+        $registry = $this->registry();
+        $path = $this->exampleRoot . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $relativePath);
+
+        $this->assertNotNull($registry->bridgeForFile($path), $relativePath);
+    }
+
+    /**
+     * @dataProvider jenssExampleProvider
+     */
+    public function testJenssExamplesExecuteThroughBridge(string $relativePath): void
+    {
+        $this->requireJenss();
+
+        $bridge = new JenssBridge();
+        $path = $this->exampleRoot . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $relativePath);
+        $context = new BridgeContext(
+            null,
+            null,
+            [],
+            [$this->exampleRoot],
+            [$this->exampleRoot],
+            [],
+            null,
+            $this->promptResponder()
+        );
+
+        $result = $bridge->runFile($path, $context);
+
+        $this->assertTrue($result->successFlag(), $relativePath . ': ' . $result->output());
+        $this->assertSame($path, $result->meta()['path'] ?? null);
+    }
+
+    /**
+     * @dataProvider vibeExampleProvider
+     */
+    public function testVibeExamplesExecuteThroughBridge(string $relativePath): void
+    {
+        if ($this->shouldSkipVibeMixRegistry()) {
+            $this->markTestSkipped('Vibe mix tags require TagRegistry regex fix.');
+        }
+        if (!class_exists(\BlueFission\Vibrato\Reader::class)) {
+            $this->markTestSkipped('Vibe interpreter not available.');
+        }
+
+        $bridge = new VibeBridge();
+        $path = $this->exampleRoot . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $relativePath);
+        $context = new BridgeContext(
+            null,
+            null,
+            [],
+            [$this->exampleRoot],
+            [$this->exampleRoot],
+            $this->varsForExample($relativePath),
+            null,
+            null,
+            null,
+            new NullLlmClient()
+        );
+
+        $result = $bridge->runFile($path, $context);
+
+        $this->assertTrue($result->successFlag(), $relativePath . ': ' . $result->output());
+        $this->assertSame($path, $result->meta()['path'] ?? null);
+    }
+
+    public static function bridgeExampleProvider(): array
+    {
+        return self::exampleProvider(['jss', 'vibe']);
+    }
+
+    public static function jenssExampleProvider(): array
+    {
+        return self::exampleProvider(['jss']);
+    }
+
+    public static function vibeExampleProvider(): array
+    {
+        return self::exampleProvider(['vibe']);
+    }
+
+    private static function exampleProvider(array $extensions): array
+    {
+        $root = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'examples' . DIRECTORY_SEPARATOR . 'root';
+        $cases = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (!$file instanceof \SplFileInfo || !$file->isFile()) {
+                continue;
+            }
+
+            if (!in_array(strtolower($file->getExtension()), $extensions, true)) {
+                continue;
+            }
+
+            $relativePath = substr($file->getPathname(), strlen($root) + 1);
+            $relativePath = str_replace(DIRECTORY_SEPARATOR, '/', $relativePath);
+            $cases[$relativePath] = [$relativePath];
+        }
+
+        ksort($cases);
+        return $cases;
+    }
+
+    private function registry(): BridgeRegistry
+    {
+        $registry = new BridgeRegistry();
+        $registry->register(new JenssBridge());
+        $registry->register(new VibeBridge());
+
+        return $registry;
+    }
+
+    private function requireJenss(): void
+    {
+        if (!class_exists(\BlueFission\Jenerator\Parsing\JenssParser::class)
+            && !class_exists(\BlueFission\Jenerate\Parsing\JenssParser::class)) {
+            $this->markTestSkipped('JenSS interpreter not available.');
+        }
+    }
+
+    private function shouldSkipVibeMixRegistry(): bool
+    {
+        $tagRegistry = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'vendor'
+            . DIRECTORY_SEPARATOR . 'bluefission'
+            . DIRECTORY_SEPARATOR . 'develation'
+            . DIRECTORY_SEPARATOR . 'src'
+            . DIRECTORY_SEPARATOR . 'Parsing'
+            . DIRECTORY_SEPARATOR . 'Registry'
+            . DIRECTORY_SEPARATOR . 'TagRegistry.php';
+        $mixRegistry = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'vendor'
+            . DIRECTORY_SEPARATOR . 'bluefission'
+            . DIRECTORY_SEPARATOR . 'vibrato'
+            . DIRECTORY_SEPARATOR . 'src'
+            . DIRECTORY_SEPARATOR . 'Vibrato'
+            . DIRECTORY_SEPARATOR . 'Parsing'
+            . DIRECTORY_SEPARATOR . 'Mix'
+            . DIRECTORY_SEPARATOR . 'MixRegistry.php';
+
+        if (!is_file($tagRegistry) || !is_file($mixRegistry)) {
+            return false;
+        }
+
+        $tagContents = file_get_contents($tagRegistry);
+        $mixContents = file_get_contents($mixRegistry);
+        if ($tagContents === false || $mixContents === false) {
+            return false;
+        }
+
+        return str_contains($tagContents, '(?P<{$tag}>') && str_contains($mixContents, 'mix:');
+    }
+
+    private function promptResponder(): callable
+    {
+        $responses = [
+            'console-user',
+            'operator',
+            'engineering',
+            'keep example scripts deterministic',
+            '80,443',
+            '22',
+            '8.8.8.8',
+            '',
+            'neutral',
+            'systems',
+            'medium',
+            'yes',
+            'no',
+        ];
+
+        return function (string $prompt) use (&$responses): string {
+            return array_shift($responses) ?? 'example';
+        };
+    }
+
+    private function varsForExample(string $relativePath): array
+    {
+        $common = [
+            'name' => 'Example User',
+            'role' => 'operator',
+            'focus' => 'engineering',
+            'tone' => 'neutral',
+            'goal' => 'verify Wise examples',
+            'resource' => 'none',
+            'nextAction' => 'run the focused smoke tests',
+            'topic' => 'example modernization',
+            'mode' => 'review',
+            'context' => 'local deterministic fixture',
+            'constraints' => 'no network and no credentials',
+            'resources' => 'JenSS, Vibe, bridge registry',
+            'outcome' => 'examples remain executable',
+            'plan' => "1. Run bridge smoke\n2. Run batch terminal\n3. Run PHPUnit",
+        ];
+
+        if ($relativePath === 'sys/res/message.vibe') {
+            return $common + [
+                'action' => 'list',
+                'recipient' => 'console',
+                'content' => 'Example message',
+                'detail' => 'Example detail',
+                'entries' => ['message-001', 'message-002'],
+            ];
+        }
+
+        return $common;
+    }
+}

--- a/tests/Examples/ExampleBridgeSmokeTest.php
+++ b/tests/Examples/ExampleBridgeSmokeTest.php
@@ -2,10 +2,11 @@
 
 namespace BlueFission\Tests\Examples;
 
+use BlueFission\Automata\LLM\Clients\IClient;
+use BlueFission\Automata\LLM\Reply;
 use BlueFission\Wise\Exe\BridgeContext;
 use BlueFission\Wise\Exe\BridgeRegistry;
 use BlueFission\Wise\Exe\JenssBridge;
-use BlueFission\Wise\Exe\NullLlmClient;
 use BlueFission\Wise\Exe\VibeBridge;
 use PHPUnit\Framework\TestCase;
 
@@ -91,13 +92,25 @@ final class ExampleBridgeSmokeTest extends TestCase
             null,
             null,
             null,
-            new NullLlmClient()
+            new ExampleFixtureLlmClient($this->generatedResponsesForExample($relativePath))
         );
 
         $result = $bridge->runFile($path, $context);
 
         $this->assertTrue($result->successFlag(), $relativePath . ': ' . $result->output());
         $this->assertSame($path, $result->meta()['path'] ?? null);
+
+        $vars = $result->meta()['variables'] ?? [];
+        if ($relativePath === 'cmd/onboard.vibe') {
+            $this->assertSame('Example User', $vars['name'] ?? null);
+            $this->assertSame('engineering', $vars['focus'] ?? null);
+            $this->assertStringContainsString('Next action:', $result->output());
+        }
+        if ($relativePath === 'cmd/strategy.vibe') {
+            $this->assertSame('example modernization', $vars['topic'] ?? null);
+            $this->assertSame('review', $vars['mode'] ?? null);
+            $this->assertStringContainsString('Plan:', $result->output());
+        }
     }
 
     public static function bridgeExampleProvider(): array
@@ -242,5 +255,64 @@ final class ExampleBridgeSmokeTest extends TestCase
         }
 
         return $common;
+    }
+
+    private function generatedResponsesForExample(string $relativePath): array
+    {
+        return match ($relativePath) {
+            'cmd/onboard.vibe' => [
+                'Example User',
+                'operator',
+                'engineering',
+                'neutral',
+                'verify Wise examples',
+                'none',
+                'run the focused smoke tests',
+            ],
+            'cmd/strategy.vibe' => [
+                'example modernization',
+                'review',
+                'local deterministic fixture',
+                'no network and no credentials',
+                'JenSS, Vibe, bridge registry',
+                'examples remain executable',
+                "1. Run bridge smoke\n2. Run batch terminal\n3. Run PHPUnit",
+                'run the focused smoke tests',
+            ],
+            default => [],
+        };
+    }
+}
+
+final class ExampleFixtureLlmClient implements IClient
+{
+    private array $responses;
+
+    public function __construct(array $responses)
+    {
+        $this->responses = $responses;
+    }
+
+    public function generate($input, $config = [], ?callable $callback = null): Reply
+    {
+        $response = (string)(array_shift($this->responses) ?? 'generated fixture response');
+        if ($callback) {
+            $callback($response);
+        }
+
+        $reply = new Reply();
+        $reply->addMessage($response);
+
+        return $reply;
+    }
+
+    public function complete($input, $config = []): Reply
+    {
+        return $this->generate($input, $config);
+    }
+
+    public function respond($input, $config = []): Reply
+    {
+        return $this->generate($input, $config);
     }
 }

--- a/tests/ExeBridgeTest.php
+++ b/tests/ExeBridgeTest.php
@@ -45,11 +45,31 @@ final class ExeBridgeTest extends TestCase
             || class_exists(\BlueFission\Jenerate\Runtime\Interpreter::class)
         ) {
             $this->assertNotNull($result);
+            $this->assertSame('wise://inline.jss', $result->meta()['path'] ?? null);
             return;
         }
 
         $this->assertFalse($result->successFlag());
         $this->assertStringContainsString('JenSS interpreter is not available', $result->output());
+    }
+
+    public function testJenssBridgeReturnsFailureForInvalidInlineSource(): void
+    {
+        if (
+            !class_exists(\BlueFission\Jenerator\Runtime\Interpreter::class)
+            && !class_exists(\BlueFission\Jenerate\Runtime\Interpreter::class)
+        ) {
+            $this->markTestSkipped('JenSS interpreter not available.');
+        }
+
+        $bridge = new JenssBridge();
+        $context = new BridgeContext();
+
+        $result = $bridge->runSource('use @system from ;', $context, 'bad-inline.jss');
+
+        $this->assertFalse($result->successFlag());
+        $this->assertStringContainsString('JenSS execution failed:', $result->output());
+        $this->assertSame('bad-inline.jss', $result->meta()['path'] ?? null);
     }
 
     public function testVibeBridgeReportsMissingDependency(): void

--- a/tests/IO/JenssStressScriptTest.php
+++ b/tests/IO/JenssStressScriptTest.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace BlueFission\Tests\IO;
+
+use BlueFission\Automata\Language\{
+    Interpreter,
+    Grammar,
+    StemmerLemmatizer,
+    Documenter,
+    Walker
+};
+use BlueFission\Data\Storage\Memory;
+use BlueFission\IPC\IPC;
+use BlueFission\Wise\Arc\Kernel;
+use BlueFission\Wise\Arc\ProcessManager;
+use BlueFission\Wise\Cli\Console;
+use BlueFission\Wise\Cmd\CommandProcessor;
+use BlueFission\Wise\Exe\BridgeContext;
+use BlueFission\Wise\Exe\BridgeRegistry;
+use BlueFission\Wise\Exe\JenssBridge;
+use BlueFission\Wise\Sys\DisplayManager;
+use BlueFission\Wise\Sys\Drivers\IDisplayDriver;
+use BlueFission\Wise\Sys\FileSystemManager;
+use BlueFission\Wise\Sys\IO\CommandInputStream;
+use BlueFission\Wise\Sys\KeyInputManager;
+use BlueFission\Wise\Sys\MemoryManager;
+use PHPUnit\Framework\TestCase;
+
+final class JenssStressScriptTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $this->resetKernelInstance();
+        $this->root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'wise-jenss-stress-' . uniqid();
+        mkdir($this->root . DIRECTORY_SEPARATOR . 'cmd', 0777, true);
+        mkdir($this->root . DIRECTORY_SEPARATOR . 'cfg' . DIRECTORY_SEPARATOR . 'agent', 0777, true);
+        mkdir($this->root . DIRECTORY_SEPARATOR . 'cfg' . DIRECTORY_SEPARATOR . 'routing', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->root);
+    }
+
+    public function testAgentReadinessScriptBuildsStatementAndFeedbackSummary(): void
+    {
+        $this->requireJenss();
+        $this->copyExample('cmd/agent-readiness.jss');
+
+        $kernel = $this->makeKernel([
+            'Harden CLI contracts',
+            'command processor',
+            'bridge output not reviewed',
+        ]);
+        $registry = new BridgeRegistry();
+        $registry->register(new JenssBridge());
+        $kernel->setBridgeRegistry($registry);
+
+        $kernel->handle('agent-readiness');
+        $output = $kernel->lastOutput();
+
+        $this->assertStringContainsString('Agent readiness review.', $output);
+        $this->assertStringContainsString('Goal: Prepare the agent environment', $output);
+        $this->assertStringContainsString('Objective: Harden CLI contracts', $output);
+        $this->assertStringContainsString('Resource: command processor', $output);
+        $this->assertStringContainsString('Risk: bridge output not reviewed', $output);
+        $this->assertStringContainsString('Resource claim:', $output);
+        $this->assertStringContainsString('Risk claim:', $output);
+        $this->assertStringContainsString('Readiness score:', $output);
+    }
+
+    public function testCommandPredictionScriptTrainsReusableSuggestionModel(): void
+    {
+        $this->requireJenss();
+        $this->copyExample('cmd/predict-command.jss');
+
+        $kernel = $this->makeKernel();
+        $registry = new BridgeRegistry();
+        $registry->register(new JenssBridge());
+        $kernel->setBridgeRegistry($registry);
+
+        $kernel->handle('predict-command');
+        $output = $kernel->lastOutput();
+
+        $this->assertStringContainsString('Command suggestion training.', $output);
+        $this->assertStringContainsString('Seeded command history: 5', $output);
+        $this->assertStringContainsString('Suggestion:', $output);
+    }
+
+    public function testResourceEventScriptShapesOutputEnvelopeMetadata(): void
+    {
+        $this->requireJenss();
+        $this->copyExample('cmd/resource-event.jss');
+
+        $kernel = $this->makeKernel();
+        $registry = new BridgeRegistry();
+        $registry->register(new JenssBridge());
+        $kernel->setBridgeRegistry($registry);
+
+        $kernel->handle('resource-event');
+        $output = $kernel->lastOutput();
+
+        $this->assertStringContainsString('Resource event envelope.', $output);
+        $this->assertStringContainsString('Output id: out-001', $output);
+        $this->assertStringContainsString('Resource: command', $output);
+        $this->assertStringContainsString('Status: waiting', $output);
+        $this->assertStringContainsString('Prompt state: suspended', $output);
+        $this->assertStringContainsString('Waiting state: waiting_for_output', $output);
+        $this->assertStringContainsString('Semantic metadata:', $output);
+    }
+
+    public function testConfigScriptsRunThroughJenssBridge(): void
+    {
+        $this->requireJenss();
+        $this->copyExample('cfg/agent/default.jss');
+        $this->copyExample('cfg/routing/default.jss');
+
+        $bridge = new JenssBridge();
+        $context = new BridgeContext(null, null, [], [$this->root]);
+
+        foreach ([
+            'cfg/agent/default.jss',
+            'cfg/routing/default.jss',
+        ] as $relativePath) {
+            $path = $this->root . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $relativePath);
+            $result = $bridge->runFile($path, $context);
+
+            $this->assertTrue($result->successFlag(), $result->output());
+            $this->assertSame('', trim($result->output()));
+        }
+    }
+
+    private function makeKernel(array $responses = []): JenssStressKernel
+    {
+        $processManager = new ProcessManager();
+        $memoryManager = new MemoryManager(300, 60);
+        $fileSystem = new FileSystemManager(['root' => $this->root]);
+        $interpreter = new Interpreter(new Grammar(new StemmerLemmatizer(), []), new Documenter(), new Walker());
+        $inputStream = new CommandInputStream($responses, false);
+        $keyInput = new KeyInputManager($inputStream, true);
+        $displayDriver = new JenssStressNullDisplayDriver();
+        $console = new Console(new DisplayManager($displayDriver), $keyInput);
+        $console->registerInputChannel('system');
+
+        return new JenssStressKernel(
+            $processManager,
+            new CommandProcessor(new Memory(), null, null),
+            $memoryManager,
+            $fileSystem,
+            $interpreter,
+            $console,
+            new Memory(),
+            new Memory(),
+            new IPC(new Memory())
+        );
+    }
+
+    private function copyExample(string $relativePath): void
+    {
+        $sourcePath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'examples'
+            . DIRECTORY_SEPARATOR . 'root'
+            . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $relativePath);
+        $targetPath = $this->root . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $relativePath);
+        $targetDir = dirname($targetPath);
+
+        if (!is_dir($targetDir)) {
+            mkdir($targetDir, 0777, true);
+        }
+
+        $source = file_get_contents($sourcePath);
+        file_put_contents($targetPath, $source !== false ? $source : '');
+    }
+
+    private function requireJenss(): void
+    {
+        if (!class_exists(\BlueFission\Jenerator\Parsing\JenssParser::class)
+            && !class_exists(\BlueFission\Jenerate\Parsing\JenssParser::class)) {
+            $this->markTestSkipped('JenSS interpreter not available.');
+        }
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($iterator as $item) {
+            if ($item->isDir()) {
+                @rmdir($item->getPathname());
+            } else {
+                @unlink($item->getPathname());
+            }
+        }
+
+        @rmdir($dir);
+    }
+
+    private function resetKernelInstance(): void
+    {
+        $reflection = new \ReflectionClass(Kernel::class);
+        if (!$reflection->hasProperty('_instance')) {
+            return;
+        }
+
+        $property = $reflection->getProperty('_instance');
+        $property->setAccessible(true);
+        $property->setValue(null, null);
+    }
+}
+
+final class JenssStressKernel extends Kernel
+{
+    public function lastOutput(): string
+    {
+        return (string)$this->_output;
+    }
+}
+
+final class JenssStressNullDisplayDriver implements IDisplayDriver
+{
+    public function handle($data, $type = null, $style = null): void
+    {
+    }
+
+    public function send($data): void
+    {
+    }
+
+    public function getContent(): array
+    {
+        return [];
+    }
+
+    public function flush(): void
+    {
+    }
+
+    public function getTerminalSize(): array
+    {
+        return [80, 24];
+    }
+
+    public function init(): void
+    {
+    }
+
+    public function update(): void
+    {
+    }
+
+    public function draw(): void
+    {
+    }
+
+    public function print(): void
+    {
+    }
+
+    public function clear(): void
+    {
+    }
+
+    public function clearScreen(): void
+    {
+    }
+}

--- a/tests/Res/BaseResourceEventTest.php
+++ b/tests/Res/BaseResourceEventTest.php
@@ -24,35 +24,88 @@ namespace BlueFission\Tests\Res {
 
     final class BaseResourceEventTest extends TestCase
     {
-        public function testEmitsUniqueOutputAndRefreshSignals(): void
+        public function testEmitsResourceOutputEnvelopeWithWaitingState(): void
         {
             $resource = new class() extends BaseResource {
                 protected $_name = 'dummy';
 
                 protected function list($args)
                 {
-                    $this->setExpectedOptions(['yes', 'no']);
+                    $this->setOutputMeta([
+                        'semantic_metadata' => [
+                            'kind' => 'unit-fixture',
+                            'confidence' => 0.88,
+                        ],
+                        'provenance' => [
+                            'source' => 'test',
+                        ],
+                    ]);
+                    $this->setExpectedOptions(['yes', 'no'], [
+                        'prompt_state' => 'suspended',
+                    ]);
                     $this->_response = 'Hello world [yes/no]';
                 }
             };
 
             $outputs = [];
-            $refreshes = [];
             $waiting = [];
 
             $resource->when('wise.resource.output', function ($behavior, $meta) use (&$outputs) {
                 if ($meta instanceof Meta) {
-                    $outputs[] = $meta->data['output'] ?? null;
-                }
-            });
-            $resource->when('wise.resource.output.refresh', function ($behavior, $meta) use (&$refreshes) {
-                if ($meta instanceof Meta) {
-                    $refreshes[] = $meta->data['output'] ?? null;
+                    $outputs[] = $meta->data;
                 }
             });
             $resource->when('wise.resource.waiting', function ($behavior, $meta) use (&$waiting) {
                 if ($meta instanceof Meta) {
-                    $waiting[] = $meta->data['options'] ?? [];
+                    $waiting[] = $meta->data;
+                }
+            });
+
+            $resource->handle(new Behavior('list'), []);
+
+            $this->assertCount(1, $outputs);
+            $this->assertCount(1, $waiting);
+
+            $output = $outputs[0];
+            $this->assertMatchesRegularExpression('/^wise-out-[a-f0-9]{16}$/', $output['output_id']);
+            $this->assertSame('dummy', $output['resource']);
+            $this->assertSame('dummy', $output['resource_name']);
+            $this->assertSame('list', $output['action']);
+            $this->assertSame('waiting', $output['status']);
+            $this->assertTrue($output['waiting']);
+            $this->assertFalse($output['completed']);
+            $this->assertFalse($output['repeated']);
+            $this->assertSame('Hello world [yes/no]', $output['output']);
+            $this->assertSame(['yes', 'no'], $waiting[0]['options']);
+            $this->assertSame($output['output_id'], $waiting[0]['output_id']);
+            $this->assertSame('suspended', $waiting[0]['prompt_state']);
+            $this->assertSame('unit-fixture', $output['semantic_metadata']['kind']);
+            $this->assertSame('test', $output['provenance']['source']);
+            $this->assertNotFalse(strtotime($output['timestamp']));
+        }
+
+        public function testRepeatedOutputUsesSameOutputIdAndRefreshSignal(): void
+        {
+            $resource = new class() extends BaseResource {
+                protected $_name = 'repeatable';
+
+                protected function list($args)
+                {
+                    $this->_response = 'Same output.';
+                }
+            };
+
+            $outputs = [];
+            $refreshes = [];
+
+            $resource->when('wise.resource.output', function ($behavior, $meta) use (&$outputs) {
+                if ($meta instanceof Meta) {
+                    $outputs[] = $meta->data;
+                }
+            });
+            $resource->when('wise.resource.output.refresh', function ($behavior, $meta) use (&$refreshes) {
+                if ($meta instanceof Meta) {
+                    $refreshes[] = $meta->data;
                 }
             });
 
@@ -61,7 +114,43 @@ namespace BlueFission\Tests\Res {
 
             $this->assertCount(1, $outputs);
             $this->assertCount(1, $refreshes);
-            $this->assertCount(1, $waiting);
+            $this->assertSame($outputs[0]['output_id'], $refreshes[0]['output_id']);
+            $this->assertFalse($outputs[0]['repeated']);
+            $this->assertTrue($refreshes[0]['repeated']);
+            $this->assertSame('completed', $outputs[0]['status']);
+            $this->assertTrue($outputs[0]['completed']);
+        }
+
+        public function testImmediateSuccessAndInvalidActionExposeCompletedStatus(): void
+        {
+            $resource = new class() extends BaseResource {
+                protected $_name = 'quick';
+
+                protected function list($args)
+                {
+                    $this->_response = 'Ready.';
+                }
+            };
+
+            $outputs = [];
+            $resource->when('wise.resource.output', function ($behavior, $meta) use (&$outputs) {
+                if ($meta instanceof Meta) {
+                    $outputs[] = $meta->data;
+                }
+            });
+
+            $resource->handle(new Behavior('list'), []);
+            $resource->handle(new Behavior('unknown'), []);
+
+            $this->assertCount(2, $outputs);
+            $this->assertSame('completed', $outputs[0]['status']);
+            $this->assertFalse($outputs[0]['waiting']);
+            $this->assertTrue($outputs[0]['completed']);
+            $this->assertSame('error', $outputs[1]['status']);
+            $this->assertSame('invalid_action', $outputs[1]['error']);
+            $this->assertSame('unknown', $outputs[1]['action']);
+            $this->assertFalse($outputs[1]['waiting']);
+            $this->assertTrue($outputs[1]['completed']);
         }
     }
 }


### PR DESCRIPTION
## Intent summary
Add interpreter-backed stress fixtures and dependency alignment for Wise bridge contracts.

## User stories / acceptance criteria
- As a bridge maintainer, JenSS scripts exercise agent readiness, command prediction, and resource event shaping.
- As a package maintainer, dependency aliases align with the installed Blue Fission package graph.
- As a reviewer, real fixture tests show which surfaces pass and which upstream paths remain blocked.

## Key files changed
- `composer.json`
- `examples/root/cfg/agent/default.jss`
- `examples/root/cfg/routing/default.jss`
- `examples/root/cmd/agent-readiness.jss`
- `examples/root/cmd/predict-command.jss`
- `examples/root/cmd/resource-event.jss`
- `tests/IO/JenssStressScriptTest.php`

## How to test
- `vendor/bin/phpunit --do-not-cache-result tests/IO/JenssStressScriptTest.php tests/ExeBridgeTest.php`
- `vendor/bin/phpunit --do-not-cache-result`

## QA checklist
- JenSS fixtures stay Wise-owned and reusable.
- Dependency alignment is package-level, not tailored to one consuming app.
- Upstream Automata failures remain visible instead of hidden by weaker local tests.

## Approval conditions
- Focused bridge and stress fixture tests pass.
- Reviewer confirms the fixtures are useful as package examples and runtime proofs.

Advances #3.
