### PR TITLE
Expand DevElation helper coverage

### DIFF
--- a/docs/develation-helper-coverage.md
+++ b/docs/develation-helper-coverage.md
@@ -15,3 +15,19 @@ Native calls intentionally retained in this file:
 - `implode` remains the response formatting boundary for joined suggestion text.
 
 Next likely audit targets are `CommandProcessor`, `CommandParser`, `Cli\Console`, and legacy resource classes with file-system or collection primitives.
+
+## Issue #14 Slice: Runtime Storage And Identity Guards
+
+This slice expands helper coverage in file-backed runtime paths and user identity/profile surfaces:
+
+- `DirectoryManager::ensurePath()` centralizes nested directory creation through the Wise DevElation-backed filesystem adapter.
+- Storage-backed resources now use `DirectoryManager::ensurePath()` instead of raw `is_dir()`, `file_exists()`, and `mkdir()` guards.
+- `Identity` and `Profile` now use `Val`, `Str`, and `Arr` for presence, empty, array, and membership checks.
+- `StepResource::perform()` now uses an `Arr` object for queue-style argument shifting instead of raw `array_shift()`.
+- `ScriptedResourceRegistry` now uses `DirectoryManager`, `Arr`, `Str`, and `Val` for runtime directory and duplicate-registration guards.
+
+Native calls intentionally retained in this slice:
+
+- `glob()` remains the filesystem enumeration boundary for Vibe resource discovery until a DevElation file enumeration API is selected for this use case.
+- `dirname()` and `basename()` remain path-boundary helpers inside `DirectoryManager::ensurePath()` while creation itself goes through `FileSystem`.
+- Existing JSON encode/decode, ranking, and external API response parsing remain outside this slice and should be audited separately.

--- a/src/Wise/Arc/Traits/ManagesFileSystem.php
+++ b/src/Wise/Arc/Traits/ManagesFileSystem.php
@@ -2,6 +2,9 @@
 
 namespace BlueFission\Wise\Arc\Traits;
 
+use BlueFission\Arr;
+use BlueFission\Val;
+
 trait ManagesFileSystem {
     public function deleteFile($file) {
         $this->_fileSystemManager->open($file);
@@ -29,18 +32,18 @@ trait ManagesFileSystem {
     }
 
     public function moveFile($destination, $file = null) {
-        if ($file) {
+        if (Val::isNotEmpty($file)) {
             $this->_fileSystemManager->open($file);
         }
-        $this->_fileSystemManager->move($new);
+        $this->_fileSystemManager->move($destination);
         return $this->_fileSystemManager->status();
     }
 
     public function copyFile($destination, $file = null) {
-        if ($file) {
+        if (Val::isNotEmpty($file)) {
             $this->_fileSystemManager->open($file);
         }
-        $this->_fileSystemManager->copy($new);
+        $this->_fileSystemManager->copy($destination);
         return $this->_fileSystemManager->status();
     }
 
@@ -56,22 +59,17 @@ trait ManagesFileSystem {
     }
 
     public function listDir($dir = null) {
-        if ($dir) {
+        if (Val::isNotEmpty($dir)) {
             $this->_fileSystemManager->open($dir);
         }
 
         $list = $this->_fileSystemManager->listDir();
 
-        if (! $list || ( is_array($list) && count($list) == 0 )) {
+        if (Val::isEmpty($list) || (Arr::is($list) && Arr::isEmpty($list))) {
             return $this->_fileSystemManager->status();
         }
 
-        $output = '';
-        foreach ($list as $item) {
-            $output .= $item . PHP_EOL;
-        }
-
-        return $output;
+        return Arr::make($list)->join(PHP_EOL)->val() . PHP_EOL;
     }
     
     public function currentDir() {

--- a/src/Wise/Cmd/CommandHandler.php
+++ b/src/Wise/Cmd/CommandHandler.php
@@ -3,6 +3,8 @@
 namespace BlueFission\Wise\Cmd;
 
 use BlueFission\Arr;
+use BlueFission\Str;
+use BlueFission\Val;
 use BlueFission\Wise\Arc\Kernel;
 use BlueFission\Data\FileSystem;
 use BlueFission\Wise\Res\ResourceHelper;
@@ -25,7 +27,7 @@ class CommandHandler {
         if ($this->shouldDeferToResource($commandName, $command)) {
             return false;
         }
-        return isset($this->_aliases[$commandName]) || method_exists($this, $commandName);
+        return Val::is($this->_aliases[$commandName] ?? null) || method_exists($this, $commandName);
     }
 
     public function handle($command) {
@@ -35,7 +37,7 @@ class CommandHandler {
         $commandName = $parts->shift();
         $args = $parts->val();
 
-        if (isset($this->_aliases[$commandName])) {
+        if (Val::is($this->_aliases[$commandName] ?? null)) {
             $commandName = $this->_aliases[$commandName];
         }
 
@@ -145,8 +147,8 @@ class CommandHandler {
             return 'Working memory is not configured.';
         }
 
-        $scope = $scope ? strtolower($scope) : null;
-        $size = $size !== null ? strtolower((string)$size) : null;
+        $scope = Val::isNotEmpty($scope) ? Str::lower((string)$scope) : null;
+        $size = Val::is($size) ? Str::lower((string)$size) : null;
 
         if ($scope === null || $scope === 'status') {
             return $this->memoryStatus();
@@ -159,7 +161,7 @@ class CommandHandler {
             $scope = 'user';
         }
 
-        if (!in_array($scope, ['user', 'global'], true)) {
+        if (!Arr::has(['user', 'global'], $scope, true)) {
             return 'Usage: memory [user|global] [size|off]';
         }
 
@@ -225,7 +227,7 @@ class CommandHandler {
     private function isResourceCommand(array $args): bool
     {
         foreach ($args as $arg) {
-            $value = strtolower((string)$arg);
+            $value = Str::lower((string)$arg);
             if ($value === 'resource' || $value === 'resources') {
                 return true;
             }
@@ -236,14 +238,14 @@ class CommandHandler {
 
     private function shouldDeferToResource(string $commandName, string $command): bool
     {
-        $commandName = strtolower($commandName);
-        if (!in_array($commandName, ['list', 'show', 'help'], true)) {
+        $commandName = Str::lower($commandName);
+        if (!Arr::has(['list', 'show', 'help'], $commandName, true)) {
             return false;
         }
 
         $parts = preg_split('/\s+/', trim($command));
         foreach ($parts as $part) {
-            $part = strtolower($part);
+            $part = Str::lower($part);
             if ($part === 'resource' || $part === 'resources') {
                 return false;
             }
@@ -267,7 +269,7 @@ class CommandHandler {
     {
         $filtered = [];
         foreach ($args as $arg) {
-            $value = strtolower((string)$arg);
+            $value = Str::lower((string)$arg);
             if ($value === 'resource' || $value === 'resources' || $value === 'all') {
                 continue;
             }

--- a/src/Wise/Cmd/CommandSuggester.php
+++ b/src/Wise/Cmd/CommandSuggester.php
@@ -58,7 +58,7 @@ class CommandSuggester
             $resource = (string)$command->resources[0];
             $verbs = $this->verbsForResource($resource);
             if ($verbs !== []) {
-                $verbs = Arr::make($verbs)->slice(0, 3);
+                $verbs = Arr::make($verbs)->slice(0, 3)->toArray();
                 $suggestions = Arr::make($verbs)
                     ->map(fn($verb) => "{$verb} {$resource}")
                     ->values()
@@ -114,7 +114,7 @@ class CommandSuggester
         }
 
         if (Str::isEmpty($token) || Arr::has($this->verbs, $token, true)) {
-            return Arr::make($this->resources)->slice(0, $limit);
+            return Arr::make($this->resources)->slice(0, $limit)->toArray();
         }
 
         return $this->rankMatches($token, $this->resources, $limit, 0.4);
@@ -126,7 +126,7 @@ class CommandSuggester
             return $this->resourceCommands[$resource];
         }
 
-        return Arr::make($this->verbs)->slice(0, 5);
+        return Arr::make($this->verbs)->slice(0, 5)->toArray();
     }
 
     private function bestMatch(string $input, array $candidates): ?string
@@ -158,6 +158,6 @@ class CommandSuggester
 
         arsort($ranked);
 
-        return Arr::make($ranked)->keys()->slice(0, $limit);
+        return Arr::make($ranked)->keys()->slice(0, $limit)->toArray();
     }
 }

--- a/src/Wise/Nav/SynthetiqBootstrap.php
+++ b/src/Wise/Nav/SynthetiqBootstrap.php
@@ -70,9 +70,7 @@ class SynthetiqBootstrap
 
         $modelDir = $config['model_path'] ?? (dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'artifacts' . DIRECTORY_SEPARATOR . 'models' . DIRECTORY_SEPARATOR . 'synthetiq');
         $modelDir = rtrim($modelDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
-        if (!DirectoryManager::pathExists($modelDir)) {
-            mkdir($modelDir, 0777, true);
-        }
+        DirectoryManager::ensurePath($modelDir);
 
         $modelFile = self::resolveModelPath($modelDir, KeywordTopicAnalyzer::class);
         if (FileSystemManager::pathExists($modelFile)) {

--- a/src/Wise/Res/APIResource.php
+++ b/src/Wise/Res/APIResource.php
@@ -4,6 +4,7 @@ namespace BlueFission\Wise\Res;
 use BlueFission\Wise\Res\BaseResource;
 use BlueFission\SimpleClients\OpenAIClient;
 use BlueFission\Data\Storage\Disk;
+use BlueFission\Wise\Sys\DirectoryManager;
 use \BlueFission\Connections\Curl;
 
 class APIResource extends BaseResource
@@ -21,9 +22,7 @@ class APIResource extends BaseResource
         parent::__construct();
 
         $storagePath = OPUS_ROOT . '/storage/system';
-        if (!is_dir($storagePath)) {
-            mkdir($storagePath, 0777, true);
-        }
+        DirectoryManager::ensurePath($storagePath);
         $this->_storage = new Disk([
             'location' => $storagePath,
             'name' => "{$this->_location}.json",

--- a/src/Wise/Res/ActionResource.php
+++ b/src/Wise/Res/ActionResource.php
@@ -4,6 +4,7 @@ namespace BlueFission\Wise\Res;
 use BlueFission\Wise\Res\BaseResource;
 use BlueFission\SimpleClients\OpenAIClient;
 use BlueFission\Data\Storage\Disk;
+use BlueFission\Wise\Sys\DirectoryManager;
 
 class ActionResource extends BaseResource
 {
@@ -20,9 +21,7 @@ class ActionResource extends BaseResource
         parent::__construct();
 
         $storagePath = OPUS_ROOT . '/storage/system';
-        if (!is_dir($storagePath)) {
-            mkdir($storagePath, 0777, true);
-        }
+        DirectoryManager::ensurePath($storagePath);
         $this->_storage = new Disk([
             'location' => $storagePath,
             'name' => "{$this->_location}.json",

--- a/src/Wise/Res/FileResource.php
+++ b/src/Wise/Res/FileResource.php
@@ -3,6 +3,7 @@ namespace BlueFission\Wise\Commands;
 
 use BlueFission\Services\Service;
 use BlueFission\Data\FileSystem;
+use BlueFission\Wise\Sys\DirectoryManager;
 
 class FileResource extends Service {
     private $_fileSystem;
@@ -71,9 +72,7 @@ class FileResource extends Service {
 
     private function createFilesDirectory() {
         $path = OPUS_ROOT . '/storage/files';
-        if (!file_exists($path)) {
-            mkdir($path, 0777, true);
-        }
+        DirectoryManager::ensurePath($path);
     }
 
     public function help() {

--- a/src/Wise/Res/NoteResource.php
+++ b/src/Wise/Res/NoteResource.php
@@ -6,6 +6,7 @@ use BlueFission\BlueCore\Business\Prompts\MakeNote;
 use BlueFission\SimpleClients\OpenAIClient;
 use BlueFission\Data\Storage\Disk;
 use BlueFission\Services\Service;
+use BlueFission\Wise\Sys\DirectoryManager;
 
 class NoteResource extends Service
 {
@@ -18,9 +19,7 @@ class NoteResource extends Service
         parent::__construct();
 
         $storagePath = OPUS_ROOT . '/storage/system';
-        if (!is_dir($storagePath)) {
-            mkdir($storagePath, 0777, true);
-        }
+        DirectoryManager::ensurePath($storagePath);
         $this->_storage = new Disk([
             'location' => $storagePath,
             'name' => 'note_data.json',

--- a/src/Wise/Res/ScheduleResource.php
+++ b/src/Wise/Res/ScheduleResource.php
@@ -4,6 +4,7 @@ namespace BlueFission\Wise\Res;
 
 use BlueFission\Data\Storage\Disk;
 use BlueFission\Services\Service;
+use BlueFission\Wise\Sys\DirectoryManager;
 use DateTime;
 
 class Schedule
@@ -30,9 +31,7 @@ class ScheduleResource extends Service
     {
         parent::__construct();
         $storagePath = OPUS_ROOT . '/storage/system';
-        if (!is_dir($storagePath)) {
-            mkdir($storagePath, 0777, true);
-        }
+        DirectoryManager::ensurePath($storagePath);
         $this->_storage = new Disk([
             'location' => $storagePath,
             'name' => 'schedule_data.json',

--- a/src/Wise/Res/ScriptedResourceRegistry.php
+++ b/src/Wise/Res/ScriptedResourceRegistry.php
@@ -2,11 +2,14 @@
 
 namespace BlueFission\Wise\Res;
 
+use BlueFission\Arr;
 use BlueFission\Obj;
 use BlueFission\Services\Application as App;
 use BlueFission\Str;
+use BlueFission\Val;
 use BlueFission\Wise\Arc\Kernel;
 use BlueFission\Wise\Exe\BridgeRegistry;
+use BlueFission\Wise\Sys\DirectoryManager;
 
 class ScriptedResourceRegistry extends Obj
 {
@@ -29,18 +32,18 @@ class ScriptedResourceRegistry extends Obj
     public function register(): void
     {
         $resourcePath = $this->rootPath . DIRECTORY_SEPARATOR . $this->resourceDir;
-        if (!is_dir($resourcePath)) {
+        if (!DirectoryManager::pathExists($resourcePath)) {
             return;
         }
 
         $files = glob($resourcePath . DIRECTORY_SEPARATOR . '*.vibe');
-        if (!is_array($files)) {
+        if (!Arr::is($files)) {
             return;
         }
 
         foreach ($files as $file) {
             $name = pathinfo($file, PATHINFO_FILENAME);
-            if ($name === '' || isset($this->registered[$name])) {
+            if (Str::isEmpty($name) || Val::is($this->registered[$name] ?? null)) {
                 continue;
             }
 

--- a/src/Wise/Res/StepResource.php
+++ b/src/Wise/Res/StepResource.php
@@ -7,6 +7,7 @@ use BlueFission\Services\Service;
 use BlueFission\Data\Storage\Disk;
 use BlueFission\Behavioral\IDispatcher;
 use BlueFission\SimpleClients\OpenAIClient;
+use BlueFission\Wise\Sys\DirectoryManager;
 
 class StepResource extends Service {
 
@@ -17,9 +18,7 @@ class StepResource extends Service {
         parent::__construct();
 
         $storagePath = OPUS_ROOT . '/storage/system';
-        if (!is_dir($storagePath)) {
-            mkdir($storagePath, 0777, true);
-        }
+        DirectoryManager::ensurePath($storagePath);
         $this->_storage = new Disk([
             'location' => $storagePath,
             'name' => 'steps_data.json',
@@ -34,11 +33,12 @@ class StepResource extends Service {
 
     public function perform( ): IDispatcher
     {
-        $args = func_get_args();
-        $behavior = array_shift( $args );
+        $args = Arr::make(func_get_args());
+        $behavior = $args->shift();
+        $args = $args->toArray(true);
 
         if ( Arr::is($behavior) ) {
-            $behavior = array_shift($behavior);
+            $behavior = Arr::make($behavior)->shift();
         }
 
         $response = "";

--- a/src/Wise/Res/TodoResource.php
+++ b/src/Wise/Res/TodoResource.php
@@ -3,6 +3,7 @@ namespace BlueFission\Wise\Res;
 
 use BlueFission\Wise\Res\BaseResource;
 use BlueFission\Data\Storage\Disk;
+use BlueFission\Wise\Sys\DirectoryManager;
 
 class TodoResource extends BaseResource
 {
@@ -18,9 +19,7 @@ class TodoResource extends BaseResource
         parent::__construct();
 
         $storagePath = OPUS_ROOT . '/storage/system';
-        if (!is_dir($storagePath)) {
-            mkdir($storagePath, 0777, true);
-        }
+        DirectoryManager::ensurePath($storagePath);
         $this->_storage = new Disk([
             'location' => $storagePath,
             'name' => "{$this->_location}.json",

--- a/src/Wise/Res/VariableResource.php
+++ b/src/Wise/Res/VariableResource.php
@@ -3,6 +3,7 @@ namespace BlueFission\Wise\Res;
 
 use BlueFission\Wise\Res\BaseResource;
 use BlueFission\Data\Storage\Disk;
+use BlueFission\Wise\Sys\DirectoryManager;
 
 class VariableResource extends BaseResource
 {
@@ -16,11 +17,9 @@ class VariableResource extends BaseResource
     {
         $this->_key = null;
         parent::__construct();
-        
+
         $storagePath = OPUS_ROOT . '/storage/system';
-        if (!is_dir($storagePath)) {
-            mkdir($storagePath, 0777, true);
-        }
+        DirectoryManager::ensurePath($storagePath);
         $this->_storage = new Disk([
             'location' => $storagePath,
             'name' => "{$this->_location}.json",

--- a/src/Wise/Sys/DirectoryManager.php
+++ b/src/Wise/Sys/DirectoryManager.php
@@ -4,6 +4,7 @@ namespace BlueFission\Wise\Sys;
 
 use BlueFission\Data\Directory;
 use BlueFission\Data\FileSystem;
+use BlueFission\Str;
 
 class DirectoryManager extends Directory
 {
@@ -20,5 +21,29 @@ class DirectoryManager extends Directory
     public static function pathIsReachable(?string $path): bool
     {
         return (new static())->isReachable($path);
+    }
+
+    public static function ensurePath(?string $path): bool
+    {
+        $path = Str::make((string)$path)->trim()->val();
+
+        if (Str::isEmpty($path)) {
+            return false;
+        }
+
+        if (self::pathExists($path)) {
+            return true;
+        }
+
+        $parent = dirname($path);
+        if ($parent !== $path && $parent !== '.' && !self::pathExists($parent)) {
+            self::ensurePath($parent);
+        }
+
+        $storage = new FileSystem(['root' => $parent, 'filter' => []]);
+        $storage->mkdir(basename($path));
+        $storage->close();
+
+        return self::pathExists($path);
     }
 }

--- a/src/Wise/Usr/Identity.php
+++ b/src/Wise/Usr/Identity.php
@@ -4,7 +4,9 @@ namespace BlueFission\Wise\Usr;
 
 use BlueFission\Wise\Arc\Kernel;
 use BlueFission\Services\Authenticator;
+use BlueFission\Arr;
 use BlueFission\Str;
+use BlueFission\Val;
 use BlueFission\Wise\Usr\Profile;
 
 class Identity {
@@ -72,10 +74,13 @@ class Identity {
 	public function profile(): Profile
 	{
 		$id = '';
-		if (isset($this->_authenticator->id) && $this->_authenticator->id !== '') {
-			$id = (string)$this->_authenticator->id;
-		} elseif (isset($this->_authenticator->username) && $this->_authenticator->username !== '') {
-			$id = (string)$this->_authenticator->username;
+		$authId = $this->_authenticator->id ?? null;
+		$authUsername = $this->_authenticator->username ?? null;
+
+		if (Val::is($authId) && Str::isNotEmpty((string)$authId)) {
+			$id = (string)$authId;
+		} elseif (Val::is($authUsername) && Str::isNotEmpty((string)$authUsername)) {
+			$id = (string)$authUsername;
 		}
 
 		if ($id === '') {
@@ -83,11 +88,12 @@ class Identity {
 		}
 
 		$roles = [];
-		if (isset($this->_authenticator->roles) && is_array($this->_authenticator->roles)) {
-			$roles = $this->_authenticator->roles;
+		$authRoles = $this->_authenticator->roles ?? null;
+		if (Val::is($authRoles) && Arr::is($authRoles)) {
+			$roles = $authRoles;
 		}
 
-		if (empty($roles)) {
+		if (Arr::isEmpty($roles)) {
 			$roles = [$this->isAuthenticated() ? 'user' : 'guest'];
 		}
 
@@ -137,10 +143,10 @@ class Identity {
 	}
 
 	private function usernameIsValid() {
-		return !empty($this->_username);
+		return Str::isNotEmpty($this->_username);
 	}
 
 	private function passwordIsValid() {
-		return !empty($this->_password);
+		return Str::isNotEmpty($this->_password);
 	}
 }

--- a/src/Wise/Usr/Profile.php
+++ b/src/Wise/Usr/Profile.php
@@ -2,6 +2,8 @@
 
 namespace BlueFission\Wise\Usr;
 
+use BlueFission\Arr;
+
 class Profile
 {
     protected string $_id;
@@ -25,6 +27,6 @@ class Profile
 
     public function hasRole(string $role): bool
     {
-        return in_array($role, $this->_roles, true);
+        return Arr::has($this->_roles, $role, true);
     }
 }

--- a/tests/Sys/DirectoryManagerTest.php
+++ b/tests/Sys/DirectoryManagerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace BlueFission\Tests\Sys;
+
+use BlueFission\Wise\Sys\DirectoryManager;
+use PHPUnit\Framework\TestCase;
+
+final class DirectoryManagerTest extends TestCase
+{
+    public function testEnsurePathCreatesNestedDirectory(): void
+    {
+        $path = dirname(__DIR__, 2)
+            . DIRECTORY_SEPARATOR . 'artifacts'
+            . DIRECTORY_SEPARATOR . 'tmp'
+            . DIRECTORY_SEPARATOR . 'directory-manager-test'
+            . DIRECTORY_SEPARATOR . 'nested';
+
+        $this->assertTrue(DirectoryManager::ensurePath($path));
+        $this->assertTrue(DirectoryManager::pathExists($path));
+    }
+
+    public function testEnsurePathRejectsEmptyPath(): void
+    {
+        $this->assertFalse(DirectoryManager::ensurePath(''));
+    }
+}


### PR DESCRIPTION
## Intent summary

Advance issue #14 by increasing Wise runtime use of DevElation primitives and helper-backed filesystem boundaries.

## User stories / acceptance criteria

- As a Wise maintainer, I want runtime storage setup to go through a Wise/DevElation directory adapter instead of raw PHP directory checks.
- As a Wise maintainer, I want identity, profile, command, registry, and step argument handling to favor `Val`, `Arr`, and `Str` helpers at high-confidence primitive boundaries.
- As a contributor, I want helper-coverage conventions documented with explicit native-boundary exceptions.

## Key files changed

- `src/Wise/Sys/DirectoryManager.php`
- `src/Wise/Res/*Resource.php` storage-backed resources
- `src/Wise/Cmd/CommandHandler.php`
- `src/Wise/Cmd/CommandSuggester.php`
- `src/Wise/Usr/Identity.php`
- `src/Wise/Usr/Profile.php`
- `docs/develation-helper-coverage.md`
- `tests/Sys/DirectoryManagerTest.php`

## How to test

```powershell
vendor\bin\phpunit.bat --do-not-cache-result tests\Sys\DirectoryManagerTest.php tests\Cmd\CommandSuggesterTest.php tests\CommandHandlerTest.php tests\CommandParserTest.php tests\IdentityProfileTest.php tests\IO\MessageResourcePipelineTest.php
git diff --check
```

Focused result: `20 tests, 41 assertions`.

## QA checklist

- [x] Runtime directory setup uses `DirectoryManager::ensurePath()`.
- [x] `array_shift()` usage in `StepResource::perform()` uses an `Arr` object.
- [x] Identity/profile guards use `Val`, `Str`, and `Arr`.
- [x] Command helper array boundaries return plain arrays after internal `Arr` usage.
- [x] Documentation names retained native boundaries.

## Approval conditions

Full-suite review should account for the current upstream dependency-contract blocker: Automata memory/ranking boot requires `BlueFission\Chronicler\Storage\Structures\WeightedCollection`, which is being tracked upstream in BlueFissionTech/automata#76 and Wise-side in issue #18.
