### PR TITLE
Harden CLI visual boot lifecycle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,10 @@
         },
         {
             "type": "vcs",
+            "url": "https://github.com/bluefissiontech/bluecore"
+        },
+        {
+            "type": "vcs",
             "url": "https://github.com/bluefissiontech/jenerator"
         },
         {
@@ -40,8 +44,8 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "bluefission/develation": "dev-master as 1.3.34-alpha",
-        "bluefission/automata": "dev-master",
+        "bluefission/develation": "^1.3.41",
+        "bluefission/automata": "dev-master as 1.0.0-alpha.2",
         "bluefission/simpleclients": "dev-master",
         "bluefission/synthetiq": "dev-main",
         "bluefission/jenerator": "dev-main",

--- a/composer.json
+++ b/composer.json
@@ -14,49 +14,6 @@
     ],
     "repositories": [
         {
-            "type": "path",
-            "url": "D:/projects/chat/intelligence",
-            "options": {
-                "symlink": true
-            }
-        },
-        {
-            "type": "path",
-            "url": "D:/projects/clients",
-            "options": {
-                "symlink": true
-            }
-        },
-        {
-            "type": "path",
-            "url": "D:/projects/synthetiq",
-            "options": {
-                "symlink": true
-            }
-        },
-        {
-            "type": "path",
-            "url": "D:/projects/vibe-interpreter",
-            "options": {
-                "symlink": true
-            }
-        },
-        {
-            "type": "path",
-            "url": "D:/projects/bluecore",
-            "options": {
-                "symlink": true
-            }
-        },
-        {
-            "type": "path",
-            "url": "D:/projects/bluefission/develation/dev-elation4/dev",
-            "options": {
-                "symlink": true
-            },
-            "version": "1.3.34-alpha"
-        },
-        {
             "type": "vcs",
             "url": "https://github.com/bluefissiontech/develation"
         },

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -1,0 +1,18 @@
+# Naming
+
+Wise keeps package-owned paths short and domain-oriented so CLI, resource, and system surfaces read like low-level shell boundaries:
+
+- `Arc` for kernel and base runtime contracts.
+- `Cli` for terminal display and input components.
+- `Cmd` for command parsing, handling, and suggestions.
+- `IO` for input/output adapters and stream contracts.
+- `Nav` for navigation, routing, and conversational adapters.
+- `Res` for user-addressable resources.
+- `Sys` for machine, memory, storage, and utility support.
+- `Usr` for identity and profile state.
+
+New source folders should reuse these domains before adding another top-level concept. When a new domain is necessary, prefer a short noun that can stay stable across shell, script, and agent use.
+
+PHP class files should continue to match class names for autoload clarity. Short folder names carry the OS-style convention; class names can stay descriptive when they define public contracts.
+
+Docs use lowercase kebab-case. Prefer short topic names for durable conventions, and use longer filenames only when the subject is a specific integration or migration contract.

--- a/examples/terminal.php
+++ b/examples/terminal.php
@@ -62,6 +62,16 @@ $sessionDirectory = new FileSystem(['root' => $rootPath, 'filter' => []]);
 if (!$sessionDirectory->exists($sessionLocation)) {
     $sessionDirectory->mkdir('artifacts');
 }
+$storageLocation = $sessionLocation . DIRECTORY_SEPARATOR . 'storage';
+if (!$sessionDirectory->exists($storageLocation)) {
+    $sessionDirectory->mkdir('artifacts' . DIRECTORY_SEPARATOR . 'storage');
+}
+if (getenv('STORAGE_PATH') === false) {
+    putenv('STORAGE_PATH=' . $storageLocation);
+}
+if (getenv('STORAGE_FILE_NAME') === false) {
+    putenv('STORAGE_FILE_NAME=wise_cli_storage.json');
+}
 
 // ini_set('display_errors', 1);
 // ini_set('display_startup_errors', 1);
@@ -193,10 +203,10 @@ if (!$batchMode && $displayMode === 'dynamic' && !Tty::isTty(STDOUT)) {
 }
 if (PHP_OS === 'WINNT' && !$batchMode && $displayMode === 'dynamic') {
     if (getenv('WISE_STDIN_PROXY') === false) {
-        putenv('WISE_STDIN_PROXY=1');
+        putenv('WISE_STDIN_PROXY=0');
     }
     if (getenv('WISE_STDIN_BLOCKING') === false) {
-        putenv('WISE_STDIN_BLOCKING=1');
+        putenv('WISE_STDIN_BLOCKING=0');
     }
 }
 if (PHP_OS === 'Linux' && !$batchMode && getenv('WISE_STDIN_BLOCKING') === false && $displayMode === 'dynamic') {
@@ -301,6 +311,9 @@ if (!$batchMode) {
         $repl->suspendInput();
     }
     $console->addComponent($screen);
+    if ($dynamicDisplay) {
+        $console->clear();
+    }
     $console->display();
 }
 
@@ -483,4 +496,4 @@ if ($batchMode) {
 }
 
 // Handle a request
-$kernel->run();
+$kernel->run(false);

--- a/src/Wise/Arc/Kernel.php
+++ b/src/Wise/Arc/Kernel.php
@@ -50,6 +50,7 @@ class Kernel {
     protected $_queue;
     protected $_output;
     protected bool $_batchMode = false;
+    protected bool $_running = false;
 
     protected static $_instance = null;
 
@@ -134,6 +135,11 @@ class Kernel {
     {
         $request = trim($request);
         // this method shoud determine if a request should be handled by the shell interpreter, the command processor, or directly by the kernel's internal commands
+
+        if ($this->isExitRequest($request)) {
+            $this->shutdown();
+            return;
+        }
 
         $this->recordMemory($request);
 
@@ -317,8 +323,11 @@ class Kernel {
         $this->recordMemoryOutput((string)$output);
     }
 
-    public function run() {
-        $this->_console->clear();
+    public function run(bool $clear = true) {
+        if ($clear) {
+            $this->_console->clear();
+        }
+        $this->_running = true;
 
         // Register input channels
         $this->_console->registerInputChannel('stdio'); // Keyboard input
@@ -332,10 +341,12 @@ class Kernel {
             $this->_output = '';
         })->bindTo($this, $this));
 
-        while (true) {
+        while ($this->_running) {
             $this->repl(); // Read, Evaluate, Print, Loop
             usleep(50000); // Sleep for 0.05 seconds
         }
+
+        $this->_console->display();
     }
 
     public function repl() {
@@ -345,7 +356,20 @@ class Kernel {
     }
 
     public function shutdown() {
-        // Shutdown kernel components
+        $this->_running = false;
+        $this->_output = 'Goodbye.';
+    }
+
+    public function isRunning(): bool
+    {
+        return $this->_running;
+    }
+
+    private function isExitRequest(string $request): bool
+    {
+        $request = Str::lower(Str::trim($request));
+
+        return in_array($request, ['exit', 'quit'], true);
     }
 
     private function maybeLogin() {

--- a/src/Wise/Cli/Components/Component.php
+++ b/src/Wise/Cli/Components/Component.php
@@ -94,7 +94,7 @@ class Component implements IDrawable
 
     public function draw(): array
     {
-        $lines = explode(PHP_EOL, wordwrap($this->getContent(), $this->getWidth(), PHP_EOL, true));
+        $lines = ConsoleDisplayUtil::wrapAnsi($this->getContent(), $this->getWidth(), $this->getHeight());
         $lines = array_slice($lines, 0, $this->getHeight());
         $this->_children->sort(fn($a, $b) => $a->getZIndex() <=> $b->getZIndex());
 
@@ -188,6 +188,17 @@ class Component implements IDrawable
         }
 
         return $this->_needsRedraw;
+    }
+
+    public function requestRedraw(): void
+    {
+        $this->_needsRedraw = true;
+
+        foreach ($this->_children as $child) {
+            if (method_exists($child, 'requestRedraw')) {
+                $child->requestRedraw();
+            }
+        }
     }
 
     public function setParent(IDrawable $parent = null): void

--- a/src/Wise/Cli/Components/SplashScreen.php
+++ b/src/Wise/Cli/Components/SplashScreen.php
@@ -19,7 +19,10 @@ class SplashScreen extends Component
     public function __construct(int $x = 0, int $y = 0, int $width = 80, int $height = 12, int $zIndex = 0)
     {
         parent::__construct($x, $y, $width, $height, '', $zIndex);
-        $this->_glitchEnabled = filter_var(getenv('WISE_SPLASH_GLITCH') ?: '0', FILTER_VALIDATE_BOOLEAN);
+        $glitch = getenv('WISE_SPLASH_GLITCH');
+        $this->_glitchEnabled = $glitch === false
+            ? PHP_OS !== 'WINNT'
+            : filter_var($glitch, FILTER_VALIDATE_BOOLEAN);
         $this->splashData();
         $this->splash();
     }
@@ -80,7 +83,7 @@ class SplashScreen extends Component
             $glitchInterval = random_int(3, 7);
             if (self::$_lastGlitch == 0 || (time() - self::$_lastGlitch) > $glitchInterval) {
                 $effect = $effects[array_rand($effects)];
-                $this->glitch($this->_splashData, [$effect => true]);
+                $content = $this->glitch($this->_splashData, [$effect => true]);
                 self::$_lastGlitch = time();
             } else {
                 $splash = preg_split("/\r?\n/", $this->_splashData);

--- a/src/Wise/Cli/Components/Traits/Glitches.php
+++ b/src/Wise/Cli/Components/Traits/Glitches.php
@@ -3,7 +3,7 @@
 namespace BlueFission\Wise\Cli\Components\Traits;
 
 trait Glitches {
-	protected function glitch($data, $args = null)
+	protected function glitch($data, $args = null): string
     {
         $lines = explode(PHP_EOL, $data);
         $colors = ['red' => 31, 'green' => 32, 'yellow' => 33, 'blue' => 34, 'magenta' => 35, 'cyan' => 36, 'white' => 37];
@@ -63,6 +63,9 @@ trait Glitches {
             }
         }
 
-        $this->_content->val(implode(PHP_EOL, $lines));
+        $content = implode(PHP_EOL, $lines);
+        $this->_content->val($content);
+
+        return $content;
     }
 }

--- a/src/Wise/Cli/Console.php
+++ b/src/Wise/Cli/Console.php
@@ -7,6 +7,7 @@ use BlueFission\Wise\Sys\{
     KeyInputManager,
 };
 use BlueFission\Wise\Cli\Components\{IDrawable, Component, Cursor, Prompt};
+use BlueFission\Wise\Cmd\CommandSuggester;
 use BlueFission\Wise\Sys\Utl\ConsoleDisplayUtil;
 use BlueFission\Behavioral\{Behaves, IDispatcher, IBehavioral};
 use BlueFission\Behavioral\Behaviors\{Event, Action, State, Meta};
@@ -36,6 +37,7 @@ class Console implements IDispatcher, IBehavioral
 
     protected ?Cursor $_activeCursor = null;
     protected ?Prompt $_activePrompt = null;
+    protected ?CommandSuggester $_commandSuggester = null;
 
     public function __construct(DisplayManager $displayManager, KeyInputManager $keyInputManager)
     {
@@ -341,30 +343,39 @@ class Console implements IDispatcher, IBehavioral
             $this->_buffer = '';
         }
 
-        if ( Str::pos($input, $this->_specialChars->flip()->get('BACKSPACE')) === 0 ) {
+        if ( $this->inputStartsWith($input, $this->_specialChars->flip()->get('BACKSPACE')) ) {
             // Handle backspace
-            $this->_buffer = Str::sub($this->_buffer, 0, -1);
+            $this->_buffer = substr($this->_buffer, 0, -1);
             $this->trigger(Event::RECEIVED, new Meta(data: new Data( channel: 'stdio', content: $this->_buffer)));
             return;
         }
 
-        if ( Str::pos($input, $this->_specialChars->flip()->get('UP')) === 0 ) {
+        if ( $this->inputStartsWith($input, $this->_specialChars->flip()->get('TAB')) ) {
+            $completion = $this->commandSuggester()->complete($this->_buffer);
+            if ($completion && $completion !== $this->_buffer) {
+                $this->_buffer = $completion;
+                $this->trigger(Event::RECEIVED, new Meta(data: new Data( channel: 'stdio', content: $this->_buffer)));
+            }
+            return;
+        }
+
+        if ( $this->inputStartsWith($input, $this->_specialChars->flip()->get('UP')) ) {
             // Handle up arrow
             return;
         }
 
-        if ( Str::pos($input, $this->_specialChars->flip()->get('DOWN')) === 0 ) {
+        if ( $this->inputStartsWith($input, $this->_specialChars->flip()->get('DOWN')) ) {
             // Handle down arrow
             return;
         }
 
-        if ( Str::pos($input, $this->_specialChars->flip()->get('RIGHT')) === 0 ) {
+        if ( $this->inputStartsWith($input, $this->_specialChars->flip()->get('RIGHT')) ) {
             // Handle right arrow by moving the cursor
             $this->send("\033[1C");
             return;
         }
 
-        if ( Str::pos($input, $this->_specialChars->flip()->get('LEFT')) === 0 ) {
+        if ( $this->inputStartsWith($input, $this->_specialChars->flip()->get('LEFT')) ) {
             // Handle left arrow by moving the cursor
             $this->send("\033[1D");
             return;
@@ -390,13 +401,44 @@ class Console implements IDispatcher, IBehavioral
     public function clear() {
         $this->_content = [];
         $this->_displayManager->clear();
+        $this->_displayManager->print();
+        $this->requestRedraw();
     }
 
     public function clearScreen() {
         $this->_displayManager->clearScreen();
+        $this->_displayManager->print();
+        $this->requestRedraw();
     }
 
     public function getDisplaySize() {
         return $this->_displayManager->getSize();
+    }
+
+    private function requestRedraw(): void
+    {
+        foreach ($this->_components as $component) {
+            if (method_exists($component, 'requestRedraw')) {
+                $component->requestRedraw();
+            }
+        }
+    }
+
+    private function commandSuggester(): CommandSuggester
+    {
+        if (!$this->_commandSuggester) {
+            $this->_commandSuggester = new CommandSuggester();
+        }
+
+        return $this->_commandSuggester;
+    }
+
+    private function inputStartsWith(string $input, ?string $prefix): bool
+    {
+        if ($prefix === null || $prefix === '') {
+            return false;
+        }
+
+        return strncmp($input, $prefix, strlen($prefix)) === 0;
     }
 }

--- a/src/Wise/Cmd/CommandHandler.php
+++ b/src/Wise/Cmd/CommandHandler.php
@@ -181,7 +181,7 @@ class CommandHandler {
     }
 
     public function exit() {
-        exit;
+        return 'Goodbye.';
     }
 
     // Add more internal commands as needed
@@ -226,7 +226,7 @@ class CommandHandler {
     {
         foreach ($args as $arg) {
             $value = strtolower((string)$arg);
-            if ($value === 'resource' || $value === 'resources') {
+            if ($value === 'all' || $value === 'resource' || $value === 'resources') {
                 return true;
             }
         }

--- a/src/Wise/Cmd/CommandParser.php
+++ b/src/Wise/Cmd/CommandParser.php
@@ -2,6 +2,7 @@
 namespace BlueFission\Wise\Cmd;
 
 use BlueFission\Services\Application as App;
+use BlueFission\Arr;
 use BlueFission\Str;
 
 // CommandParser.php
@@ -136,9 +137,31 @@ class CommandParser
         $firstWord = strtolower($words[0]);
 
         if (array_key_exists($firstWord, $this->questionKeywords)) {
-            $service = $this->questionKeywords[$firstWord];
-            $behavior = 'search';
-            $args = array_slice($words, 1);
+            $resource = null;
+            foreach ($words as $word) {
+                $normalized = $this->normalizeResource($word);
+                if ($normalized && $this->isResource($normalized)) {
+                    $resource = $normalized;
+                    break;
+                }
+            }
+
+            $service = $resource ?? $this->questionKeywords[$firstWord];
+            $behavior = $resource === 'weather' ? 'get' : 'search';
+            $ignored = Arr::merge(
+                $this->noiseWords,
+                $this->prepositions,
+                [$firstWord, 'is', 'are', 'do', 'does', 'current', 'today']
+            );
+            $args = [];
+            foreach ($words as $word) {
+                $normalized = $this->normalizeResource($word);
+                $lower = strtolower(trim($word, " \t\n\r\0\x0B,.!?;"));
+                if ($normalized === $service || in_array($lower, $ignored, true)) {
+                    continue;
+                }
+                $args[] = trim($word, " \t\n\r\0\x0B,.!?;");
+            }
 
             $command = new Command();
 

--- a/src/Wise/Cmd/CommandSuggester.php
+++ b/src/Wise/Cmd/CommandSuggester.php
@@ -24,7 +24,7 @@ class CommandSuggester
         $this->refresh();
 
         if ($input === '') {
-            return 'try: list all resources | help';
+            return 'tab: list all resources';
         }
 
         $command = $this->parser->parse($input);
@@ -34,7 +34,7 @@ class CommandSuggester
         if (!$command->verb && $lastToken !== '') {
             $verb = $this->bestMatch($lastToken, $this->verbs);
             if ($verb) {
-                return "suggest: {$verb} <resource>";
+                return "tab: {$verb} <resource>";
             }
         }
 
@@ -42,10 +42,10 @@ class CommandSuggester
             $resourceHints = $this->suggestResources($lastToken, 3);
             if ($resourceHints !== []) {
                 $suggestions = array_map(fn($resource) => "{$command->verb} {$resource}", $resourceHints);
-                return 'suggest: ' . implode(' | ', $suggestions);
+                return 'tab: ' . implode(' | ', $suggestions);
             }
 
-            return "suggest: {$command->verb} <resource>";
+            return "tab: {$command->verb} <resource>";
         }
 
         if (!$command->verb && !empty($command->resources)) {
@@ -54,16 +54,54 @@ class CommandSuggester
             if ($verbs !== []) {
                 $verbs = array_slice($verbs, 0, 3);
                 $suggestions = array_map(fn($verb) => "{$verb} {$resource}", $verbs);
-                return 'suggest: ' . implode(' | ', $suggestions);
+                return 'tab: ' . implode(' | ', $suggestions);
             }
         }
 
         $matches = $this->rankMatches($input, $this->commands, 3, 0.6);
         if ($matches !== []) {
-            return 'suggest: ' . implode(' | ', $matches);
+            return 'tab: ' . implode(' | ', $matches);
         }
 
         return '';
+    }
+
+    public function complete(string $input): ?string
+    {
+        $input = trim($input);
+        $this->refresh();
+
+        if ($input === '') {
+            return 'list all resources';
+        }
+
+        $command = $this->parser->parse($input);
+        $tokens = preg_split('/\s+/', $input);
+        $lastToken = strtolower((string)($tokens[count($tokens) - 1] ?? ''));
+
+        if (!$command->verb && $lastToken !== '') {
+            $verb = $this->bestMatch($lastToken, $this->verbs);
+            return $verb ? "{$verb} " : null;
+        }
+
+        if ($command->verb && empty($command->resources)) {
+            $resourceHints = $this->suggestResources($lastToken, 1);
+            if ($resourceHints !== []) {
+                return trim("{$command->verb} {$resourceHints[0]}");
+            }
+        }
+
+        if (!$command->verb && !empty($command->resources)) {
+            $resource = (string)$command->resources[0];
+            $verbs = $this->verbsForResource($resource);
+            if ($verbs !== []) {
+                return trim("{$verbs[0]} {$resource}");
+            }
+        }
+
+        $matches = $this->rankMatches($input, $this->commands, 1, 0.6);
+
+        return $matches[0] ?? null;
     }
 
     private function refresh(): void
@@ -100,6 +138,10 @@ class CommandSuggester
             return [];
         }
 
+        if ($token === 'list') {
+            return array_slice(['all resources', 'all commands', 'todo'], 0, $limit);
+        }
+
         if ($token === '' || in_array($token, $this->verbs, true)) {
             return array_slice($this->resources, 0, $limit);
         }
@@ -133,6 +175,10 @@ class CommandSuggester
         foreach ($candidates as $candidate) {
             $candidate = (string)$candidate;
             if ($candidate === '') {
+                continue;
+            }
+            if (str_starts_with(strtolower($candidate), $input)) {
+                $ranked[$candidate] = max($ranked[$candidate] ?? 0, 1.0);
                 continue;
             }
             similar_text($input, strtolower($candidate), $percent);

--- a/src/Wise/Nav/SynthetiqBootstrap.php
+++ b/src/Wise/Nav/SynthetiqBootstrap.php
@@ -10,6 +10,7 @@ use BlueFission\Automata\Language\{Interpreter, Grammar, StemmerLemmatizer, Walk
 use BlueFission\Automata\Analysis\KeywordTopicAnalyzer;
 use BlueFission\Automata\Strategy\NaiveBayesTextClassification;
 use BlueFission\Automata\Context;
+use BlueFission\Arr;
 use BlueFission\Str;
 use BlueFission\Wise\Sys\DirectoryManager;
 use BlueFission\Wise\Sys\FileSystemManager;
@@ -42,6 +43,8 @@ class SynthetiqBootstrap
         $grammar = require $configPath . DIRECTORY_SEPARATOR . 'grammar.php';
         $tokens = require $configPath . DIRECTORY_SEPARATOR . 'tokens.php';
         $documenter = require $configPath . DIRECTORY_SEPARATOR . 'documenter.php';
+        $dialogue = Arr::merge($dialogue, WiseSynthetiqSamples::dialogue());
+        $intentBoosts = Arr::merge($intentBoosts, WiseSynthetiqSamples::intentBoosts());
 
         return self::fromConfig([
             'dialogue' => $dialogue,

--- a/src/Wise/Nav/WiseSynthetiqSamples.php
+++ b/src/Wise/Nav/WiseSynthetiqSamples.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace BlueFission\Wise\Nav;
+
+final class WiseSynthetiqSamples
+{
+    public static function dialogue(): array
+    {
+        return [
+            'wise.command.discovery' => [
+                ['wise.command.discovery.response'],
+                [
+                    'what commands can I use?',
+                    'how do I list resources?',
+                    'show available resources',
+                    'list all resources',
+                    'list all commands',
+                    'help me use wise',
+                ],
+                ['wise', 'command', 'commands', 'resource', 'resources', 'help'],
+            ],
+            'wise.command.discovery.response' => [
+                [],
+                [
+                    'Use `list all resources`, `list all commands`, or `help` to inspect available Wise commands.',
+                ],
+                ['wise', 'command', 'resources', 'help'],
+            ],
+            'wise.weather.question' => [
+                ['wise.weather.response'],
+                [
+                    'what is the weather?',
+                    'what is the weather today?',
+                    'how is the weather?',
+                    'what is the weather in a city?',
+                    'show the weather for a location',
+                ],
+                ['weather', 'forecast', 'temperature', 'location'],
+            ],
+            'wise.weather.response' => [
+                [],
+                [
+                    'Use `get the weather in <location>` to ask Wise for weather through the weather resource.',
+                ],
+                ['weather', 'forecast', 'location'],
+            ],
+            'wise.todo.discovery' => [
+                ['wise.todo.discovery.response'],
+                [
+                    'show my lists',
+                    'show all lists',
+                    'get lists',
+                    'list todos',
+                    'show todo lists',
+                ],
+                ['todo', 'todos', 'list', 'lists', 'task', 'tasks'],
+            ],
+            'wise.todo.discovery.response' => [
+                [],
+                [
+                    'Use `list todo` to inspect todo lists, or `add <item> to todo` when a todo resource is configured.',
+                ],
+                ['todo', 'todos', 'list', 'task'],
+            ],
+        ];
+    }
+
+    public static function intentBoosts(): array
+    {
+        return [
+            'wise.command.discovery' => [
+                'priority' => 25,
+                'train_statements' => true,
+                'keywords' => [
+                    'wise command',
+                    'wise commands',
+                    'list all resources',
+                    'list all commands',
+                    'available resources',
+                    'help',
+                ],
+            ],
+            'wise.weather.question' => [
+                'priority' => 25,
+                'train_statements' => true,
+                'keywords' => [
+                    'weather',
+                    'forecast',
+                    'weather today',
+                    'weather in',
+                ],
+            ],
+            'wise.todo.discovery' => [
+                'priority' => 24,
+                'train_statements' => true,
+                'keywords' => [
+                    'todo',
+                    'todos',
+                    'show my lists',
+                    'show all lists',
+                    'get lists',
+                    'list todos',
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Wise/Sys/Utl/ConsoleDisplayUtil.php
+++ b/src/Wise/Sys/Utl/ConsoleDisplayUtil.php
@@ -137,7 +137,7 @@ class ConsoleDisplayUtil {
 
     public static function updateBuffer($line, $content) {
         if ($line >= 0 && $line < count(self::$_newBuffer)) {
-            self::$_newBuffer[$line] = str_pad(mb_substr($content, 0, self::$screenWidth), self::$screenWidth);
+            self::$_newBuffer[$line] = self::fitLine($content, self::$screenWidth);
         }
     }
 
@@ -159,46 +159,18 @@ class ConsoleDisplayUtil {
                 // Move the cursor to the line that needs updating
                 echo "\033[" . ($i + 1) . ";1H";
 
-                $currentLine = self::$_currentBuffer[$i];
                 $newLine = self::$_newBuffer[$i];
-
                 $parsedNewLine = self::parseAnsiCodes($newLine);
-                $parsedCurrentLine = self::parseAnsiCodes($currentLine);
-
-                $length = max(mb_strlen($parsedNewLine['content']), mb_strlen($parsedCurrentLine['content']));
-
-                $lineBuffer = '';
-                $prevAnsiState = '';
-                $lineHasAnsi = false;
-
+                $visible = $parsedNewLine['content'];
+                $length = mb_strlen($visible);
                 for ($j = 0; $j < $length; $j++) {
-                    if ($j >= mb_strlen($parsedCurrentLine['content']) || $j >= mb_strlen($parsedNewLine['content']) || (mb_substr($parsedCurrentLine['content'], $j, 1) !== mb_substr($parsedNewLine['content'], $j, 1) || mb_substr($parsedNewLine['content'], $j, 1) == ' ')) {
-                        // If there's an ANSI code to apply, apply it
-                        if (isset($parsedNewLine['ansiCodes'][$j])) {
-                            $lineBuffer .= $parsedNewLine['ansiCodes'][$j];
-                            $prevAnsiState = $parsedNewLine['ansiCodes'][$j];
-                            $lineHasAnsi = true;
-                        } else {
-                            // Apply the previous line's ANSI state if no new code
-                            $lineBuffer .= $prevAnsiState;
-                        }
-
-                        // Append the character to the line buffer
-                        $lineBuffer .= mb_substr($parsedNewLine['content'], $j, 1) ?? ' ';
-                    } else {
-                        // Preserve the character if it's the same
-                        $lineBuffer .= mb_substr($parsedCurrentLine['content'], $j, 1);
-                    }
-
-                    // Update the cursor position
-                    if (mb_substr($parsedNewLine['content'], $j, 1) !== ' ') {
+                    if (mb_substr($visible, $j, 1) !== ' ') {
                         self::$_cursorPosition = [$j + 1, $i + 1];
                     }
                 }
 
                 // Clear the line first and then print the updated line from buffer
-                $suffix = $lineHasAnsi ? "\033[0m" : '';
-                echo "\033[2K" . $lineBuffer . $suffix;
+                echo "\033[2K" . $newLine . "\033[0m";
                 self::$_currentBuffer[$i] = self::$_newBuffer[$i];
             }
         }
@@ -209,7 +181,7 @@ class ConsoleDisplayUtil {
     }
 
     public static function parseAnsiCodes($line) {
-        $ansiCodePattern = '/\033\[[0-9;]*m/';
+        $ansiCodePattern = '/\033\[[0-9;?]*[A-Za-z]/';
         preg_match_all($ansiCodePattern, $line, $matches, PREG_OFFSET_CAPTURE);
 
         $offset = 0;
@@ -226,6 +198,78 @@ class ConsoleDisplayUtil {
         return $parsedLine;
     }
 
+    public static function fitLine(string $line, int $width): string
+    {
+        $width = max(0, $width);
+        if ($width === 0) {
+            return '';
+        }
+
+        $wrapped = self::wrapAnsi($line, $width, 1);
+        $output = $wrapped[0] ?? '';
+        $visibleLength = mb_strlen(self::parseAnsiCodes($output)['content']);
+
+        if ($visibleLength < $width) {
+            $output .= str_repeat(' ', $width - $visibleLength);
+        }
+
+        return $output;
+    }
+
+    public static function wrapAnsi(string $content, int $width, ?int $height = null): array
+    {
+        $width = max(1, $width);
+        $lines = [];
+        $logicalLines = preg_split('/\r\n|\r|\n/', $content);
+        if (!is_array($logicalLines)) {
+            $logicalLines = [$content];
+        }
+
+        foreach ($logicalLines as $logicalLine) {
+            foreach (self::wrapAnsiLine($logicalLine, $width) as $line) {
+                $lines[] = $line;
+                if ($height !== null && count($lines) >= $height) {
+                    return $lines;
+                }
+            }
+        }
+
+        return $lines !== [] ? $lines : [''];
+    }
+
+    private static function wrapAnsiLine(string $line, int $width): array
+    {
+        preg_match_all('/\033\[[0-9;?]*[A-Za-z]|./us', $line, $matches);
+        $tokens = $matches[0] ?? [];
+        if ($tokens === []) {
+            return [''];
+        }
+
+        $lines = [];
+        $output = '';
+        $visibleLength = 0;
+
+        foreach ($tokens as $token) {
+            if (preg_match('/^\033\[[0-9;?]*[A-Za-z]$/', $token)) {
+                $output .= $token;
+                continue;
+            }
+
+            if ($visibleLength >= $width) {
+                $lines[] = $output;
+                $output = '';
+                $visibleLength = 0;
+            }
+
+            $output .= $token;
+            $visibleLength++;
+        }
+
+        $lines[] = $output;
+
+        return $lines;
+    }
+
     public static function colorize($data, $color) {
 
         return self::display("\033[{$color}m{$data}\033[0m");
@@ -240,13 +284,10 @@ class ConsoleDisplayUtil {
     }
 
     public static function clear() {
-        if (strncasecmp(PHP_OS, 'WIN', 3) == 0) {
-            system('cls');
-        } else {
-            system('clear');
-        }
+        self::initializeBuffers(self::$_currentBuffer, self::$_newBuffer, self::$screenWidth ?? 80, self::$screenHeight ?? 24);
+        self::$_cursorPosition = [0, 0];
 
-        return self::display("\033[2J\033[1;1H");
+        return self::display("\033[2J\033[3J\033[H");
     }
 
     public static function clearLine() {
@@ -258,13 +299,7 @@ class ConsoleDisplayUtil {
     }
 
     public static function clearScreen() {
-        self::display("\033[H\033[J");
-
-        for ($i = 0; $i < self::$screenHeight; $i++) {
-            self::display("\r" . str_repeat(' ', self::$screenWidth) . "\r"); // Clear line
-        }
-
-        self::display("\033[H"); // Move cursor to the top left again
+        return self::clear();
     }
 
     public static function clearLineToEnd() {

--- a/tests/Cli/ReplKeyInputTest.php
+++ b/tests/Cli/ReplKeyInputTest.php
@@ -60,6 +60,33 @@ final class ReplKeyInputTest extends TestCase
         $this->assertNotSame('', $repl->hintValue());
     }
 
+    public function testTabCompletesPromptBuffer(): void
+    {
+        $input = new SequenceInputSource(['lis', "\t"]);
+        $console = $this->makeConsole($input);
+        $repl = new REPL();
+        $console->addComponent($repl);
+
+        $console->listen();
+        $console->listen();
+
+        $this->assertSame('list ', $repl->inputValue());
+    }
+
+    public function testTabWithLongPromptDoesNotTriggerStringOffsetWarnings(): void
+    {
+        $content = str_repeat('x', 180);
+        $input = new SequenceInputSource([$content, "\t"]);
+        $console = $this->makeConsole($input);
+        $repl = new REPL();
+        $console->addComponent($repl);
+
+        $console->listen();
+        $console->listen();
+
+        $this->assertSame($content, $repl->inputValue());
+    }
+
     private function makeConsole(IInputSource $input): Console
     {
         $keyInput = new KeyInputManager($input, true);

--- a/tests/Cli/SplashScreenTest.php
+++ b/tests/Cli/SplashScreenTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace BlueFission\Tests\Cli;
+
+use BlueFission\Wise\Cli\Components\SplashScreen;
+use PHPUnit\Framework\TestCase;
+
+final class SplashScreenTest extends TestCase
+{
+    public function testGlitchSplashKeepsLogoContent(): void
+    {
+        $previous = getenv('WISE_SPLASH_GLITCH');
+        putenv('WISE_SPLASH_GLITCH=1');
+
+        $lastGlitch = new \ReflectionProperty(SplashScreen::class, '_lastGlitch');
+        $lastGlitch->setAccessible(true);
+        $lastGlitch->setValue(0);
+
+        try {
+            $splash = new SplashScreen();
+            $lines = $splash->draw();
+        } finally {
+            putenv($previous === false ? 'WISE_SPLASH_GLITCH' : 'WISE_SPLASH_GLITCH=' . $previous);
+        }
+
+        $workspaceLine = null;
+        foreach ($lines as $index => $line) {
+            if (str_contains($line, 'Workspace Intelligence Shell Environment')) {
+                $workspaceLine = $index;
+                break;
+            }
+        }
+
+        $this->assertNotNull($workspaceLine);
+        $this->assertGreaterThan(3, $workspaceLine);
+    }
+}

--- a/tests/Cli/TerminalScriptInteractionTest.php
+++ b/tests/Cli/TerminalScriptInteractionTest.php
@@ -18,6 +18,13 @@ final class TerminalScriptInteractionTest extends TestCase
     protected function tearDown(): void
     {
         $this->removeDir($this->tempDir);
+        $defaultStorage = $this->projectRoot()
+            . DIRECTORY_SEPARATOR . 'artifacts'
+            . DIRECTORY_SEPARATOR . 'storage'
+            . DIRECTORY_SEPARATOR . 'wise_cli_storage.json';
+        if (DirectoryManager::pathExists($defaultStorage)) {
+            @unlink($defaultStorage);
+        }
     }
 
     public function testBatchCliProcessesInputFileAndPrintsDeterministicOutput(): void
@@ -39,11 +46,28 @@ final class TerminalScriptInteractionTest extends TestCase
         $this->assertDoesNotMatchRegularExpression('/\x1b\[[0-9;?]*[A-Za-z]/', $result['stdout']);
     }
 
+    public function testBatchCliUsesWiseStorageDefaultsForResourceHelper(): void
+    {
+        $inputFile = $this->tempDir . DIRECTORY_SEPARATOR . 'commands.txt';
+        file_put_contents($inputFile, "list all\nexit\n");
+
+        $result = $this->runCli([
+            '--input-file', $inputFile,
+            '--display-mode', 'static',
+            '--output-mode', 'console',
+            '--input-exit',
+        ], false);
+
+        $this->assertSame(0, $result['exitCode'], $result['stderr']);
+        $this->assertSame('', $result['stderr']);
+        $this->assertStringContainsString('List of available resources:', $result['stdout']);
+    }
+
     /**
      * @param array<int, string> $args
      * @return array{exitCode:int, stdout:string, stderr:string}
      */
-    private function runCli(array $args): array
+    private function runCli(array $args, bool $injectStorageEnv = true): array
     {
         $cmd = array_merge([PHP_BINARY, $this->projectRoot() . DIRECTORY_SEPARATOR . 'terminal.php'], $args);
         $command = implode(' ', array_map('escapeshellarg', $cmd));
@@ -58,8 +82,12 @@ final class TerminalScriptInteractionTest extends TestCase
         $env['WISE_DISPLAY_MODE'] = 'static';
         $env['WISE_INPUT_EXIT'] = '1';
         $env['WISE_TTY_ECHO'] = '0';
-        $env['STORAGE_PATH'] = $this->tempDir;
-        $env['STORAGE_FILE_NAME'] = 'wise_cli_test_storage.json';
+        if ($injectStorageEnv) {
+            $env['STORAGE_PATH'] = $this->tempDir;
+            $env['STORAGE_FILE_NAME'] = 'wise_cli_test_storage.json';
+        } else {
+            unset($env['STORAGE_PATH'], $env['STORAGE_FILE_NAME']);
+        }
         $env['CLI_SESSION_ID'] = 'wise-cli-test';
 
         $process = proc_open($command, $descriptors, $pipes, $this->projectRoot(), $env);

--- a/tests/Cmd/CommandSuggesterTest.php
+++ b/tests/Cmd/CommandSuggesterTest.php
@@ -12,8 +12,8 @@ final class CommandSuggesterTest extends TestCase
         $suggester = new CommandSuggester();
         $hint = $suggester->hint('');
 
+        $this->assertStringContainsString('tab:', $hint);
         $this->assertStringContainsString('list all resources', $hint);
-        $this->assertStringContainsString('help', $hint);
     }
 
     public function testSuggestsVerbForPartialInput(): void
@@ -29,6 +29,20 @@ final class CommandSuggesterTest extends TestCase
         $suggester = new CommandSuggester();
         $hint = $suggester->hint('list');
 
-        $this->assertStringContainsString('list', $hint);
+        $this->assertStringContainsString('list all resources', $hint);
+    }
+
+    public function testCompletesPartialVerb(): void
+    {
+        $suggester = new CommandSuggester();
+
+        $this->assertSame('list ', $suggester->complete('lis'));
+    }
+
+    public function testCompletesListToResourceDiscovery(): void
+    {
+        $suggester = new CommandSuggester();
+
+        $this->assertSame('list all resources', $suggester->complete('list'));
     }
 }

--- a/tests/CommandHandlerTest.php
+++ b/tests/CommandHandlerTest.php
@@ -15,6 +15,7 @@ final class CommandHandlerTest extends TestCase
 
         $this->assertTrue($handler->canHandle('list something'));
         $this->assertTrue($handler->canHandle('listDir'));
+        $this->assertTrue($handler->canHandle('list all resources'));
         $this->assertFalse($handler->canHandle('unknown'));
     }
 
@@ -29,6 +30,17 @@ final class CommandHandlerTest extends TestCase
         $this->assertSame(['listDir', 'docs'], $kernel->lastCall);
     }
 
+    public function testListAllUsesResourceHelperInsteadOfFilesystem(): void
+    {
+        $kernel = new FakeKernel();
+        $handler = new CommandHandler($kernel);
+
+        $result = $handler->handle('list all');
+
+        $this->assertStringContainsString('List of available resources:', $result);
+        $this->assertSame([], $kernel->lastCall);
+    }
+
     public function testHandleEchoReturnsMessage(): void
     {
         $handler = new CommandHandler(new FakeKernel());
@@ -36,6 +48,13 @@ final class CommandHandlerTest extends TestCase
         $result = $handler->handle('echo hello');
 
         $this->assertSame('hello', $result);
+    }
+
+    public function testExitReturnsMessageWithoutTerminatingProcess(): void
+    {
+        $handler = new CommandHandler(new FakeKernel());
+
+        $this->assertSame('Goodbye.', $handler->handle('exit'));
     }
 
     public function testClearScreenReturnsEscapeSequence(): void

--- a/tests/CommandParserTest.php
+++ b/tests/CommandParserTest.php
@@ -54,4 +54,16 @@ final class CommandParserTest extends TestCase
         $this->assertSame(['model'], $command->resources);
         $this->assertSame(['time'], $command->args);
     }
+
+    public function testProcessQuestionPrefersNamedResource(): void
+    {
+        $parser = new CommandParser();
+
+        $command = $parser->processQuestion('what is the weather?');
+
+        $this->assertNotNull($command);
+        $this->assertSame('get', $command->verb);
+        $this->assertSame(['weather'], $command->resources);
+        $this->assertSame([], $command->args);
+    }
 }

--- a/tests/ConsoleDisplayUtilTest.php
+++ b/tests/ConsoleDisplayUtilTest.php
@@ -46,4 +46,23 @@ final class ConsoleDisplayUtilTest extends TestCase
         $this->assertSame('hello', $parsed['content']);
         $this->assertArrayHasKey(0, $parsed['ansiCodes']);
     }
+
+    public function testWrapAnsiDoesNotSplitEscapeSequences(): void
+    {
+        $input = str_repeat('x', 79) . "\033[0m" . 'y';
+        $lines = ConsoleDisplayUtil::wrapAnsi($input, 80);
+
+        foreach ($lines as $line) {
+            $this->assertDoesNotMatchRegularExpression('/(?<!\x1b)\[[0-9;]*m/', $line);
+        }
+    }
+
+    public function testFitLinePreservesCompleteAnsiSequences(): void
+    {
+        $input = "\033[90m" . str_repeat('x', 90) . "\033[0m";
+        $line = ConsoleDisplayUtil::fitLine($input, 80);
+
+        $this->assertDoesNotMatchRegularExpression('/(?<!\x1b)\[[0-9;]*m/', $line);
+        $this->assertSame(80, mb_strlen(ConsoleDisplayUtil::parseAnsiCodes($line)['content']));
+    }
 }

--- a/tests/IO/CommandPipelineTest.php
+++ b/tests/IO/CommandPipelineTest.php
@@ -92,6 +92,17 @@ final class CommandPipelineTest extends TestCase
         $this->assertStringContainsString(DIRECTORY_SEPARATOR . 'cmd' . DIRECTORY_SEPARATOR . 'status.jss', $paths[1]);
     }
 
+    public function testExitRequestStopsKernelWithoutCommandDispatch(): void
+    {
+        $kernel = $this->makeKernel();
+        $kernel->markRunningForTest();
+
+        $kernel->handle('exit');
+
+        $this->assertSame('Goodbye.', $kernel->lastOutput());
+        $this->assertFalse($kernel->isRunning());
+    }
+
     private function makeKernel(): TestKernel
     {
         $processManager = new ProcessManager();
@@ -151,6 +162,11 @@ final class CommandPipelineTest extends TestCase
 
 final class TestKernel extends Kernel
 {
+    public function markRunningForTest(): void
+    {
+        $this->_running = true;
+    }
+
     public function lastOutput(): string
     {
         return (string)$this->_output;

--- a/tests/SynthetiqSamplesTest.php
+++ b/tests/SynthetiqSamplesTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace BlueFission\Tests;
+
+use BlueFission\Wise\Nav\WiseSynthetiqSamples;
+use PHPUnit\Framework\TestCase;
+
+final class SynthetiqSamplesTest extends TestCase
+{
+    public function testWiseSamplesIncludeCliGuidanceIntents(): void
+    {
+        $dialogue = WiseSynthetiqSamples::dialogue();
+        $boosts = WiseSynthetiqSamples::intentBoosts();
+
+        $this->assertArrayHasKey('wise.command.discovery', $dialogue);
+        $this->assertArrayHasKey('wise.weather.question', $dialogue);
+        $this->assertArrayHasKey('wise.todo.discovery', $dialogue);
+        $this->assertSame(25, $boosts['wise.command.discovery']['priority']);
+    }
+}


### PR DESCRIPTION
## Intent summary

Close the CLI visual boot and interaction stability slice for issue #1.

## User stories / acceptance criteria

- As a CLI user, visual mode should clear/redraw cleanly before training and splash output.
- As a WSL/Linux user, splash rendering and suggestion repainting should not leave phantom ANSI fragments or blank the prompt without feedback.
- As a Windows CLI user, startup should avoid broken stdin handling and messy boot output.
- As a command user, `exit` should shut down cleanly instead of surfacing filesystem/storage errors.

## Key files changed

- `examples/terminal.php`
- `src/Wise/Arc/Kernel.php`
- `src/Wise/Cli/Console.php`
- `src/Wise/Cli/Components/*`
- `src/Wise/Cmd/CommandHandler.php`
- `src/Wise/Cmd/CommandParser.php`
- `src/Wise/Cmd/CommandSuggester.php`
- `src/Wise/Nav/SynthetiqBootstrap.php`
- `src/Wise/Nav/WiseSynthetiqSamples.php`
- `src/Wise/Sys/Utl/ConsoleDisplayUtil.php`
- focused CLI, command, Synthetiq sample, and terminal interaction tests

## How to test

```powershell
vendor\bin\phpunit.bat --do-not-cache-result tests\ConsoleDisplayUtilTest.php tests\CommandHandlerTest.php tests\IO\CommandPipelineTest.php tests\Cli\ReplKeyInputTest.php tests\Cli\SplashScreenTest.php tests\CliComponentsTest.php tests\Cmd\CommandSuggesterTest.php tests\CommandParserTest.php tests\CommandParserRoutingTest.php tests\SynthetiqSamplesTest.php tests\Cli\TerminalScriptInteractionTest.php tests\Examples\ExampleBridgeSmokeTest.php tests\IO\JenssStressScriptTest.php tests\Res\BaseResourceEventTest.php
php terminal.php --input-file=examples\batch-commands.txt --display-mode=static --output-mode=console
git diff --cached --check
```

Focused result: `100 tests, 230 assertions`; existing PHPUnit deprecations remain.

## QA checklist

- [x] Visual boot clears/redraws before progress output.
- [x] Splash no longer clears to blank after initial training.
- [x] Tab suggestion acceptance avoids the DevElation `Str` control-byte offset warning.
- [x] `list all` / `list all resources` route through resource helpers instead of virtual filesystem paths.
- [x] `exit` / `quit` stop the kernel loop cleanly.
- [x] Batch static CLI smoke output remains deterministic.

## Approval conditions

Manual terminal review is still useful on WSL2 and Windows PowerShell because this PR addresses visual repaint and raw-key behavior that automated CLI tests can only approximate.
