### PR TITLE
Add Synthetiq context handoff contract

### DIFF
--- a/docs/synthetiq-context-handoff.md
+++ b/docs/synthetiq-context-handoff.md
@@ -1,0 +1,31 @@
+# Synthetiq Context Handoff
+
+Wise treats Synthetiq as an optional conversation and routing adapter. The package boundary is a structured handoff, not a shared ownership of Wise command execution.
+
+Synthetiq-facing fields:
+
+- `conversation_profile`
+- `context_refs`
+- `current_intent`
+- `unresolved_questions`
+- `confidence`
+- `declared_capabilities`
+- `provenance`
+- `handoff_status`
+- `diagnostics`
+- `output_id`
+
+Wise-owned envelope fields:
+
+- `invocation_id`
+- `session_id`
+- `scope`
+- `safety_policy`
+- `execution_state`
+- `waiting_state`
+- `completed_at`
+- `exit_status`
+
+`SynthetiqContextHandoff::deterministicFixture()` provides the first side-effect-free compatibility fixture: route classification with bounded context refs, no declared external capabilities, accepted status, and a stable `output_id`.
+
+Runtime failures should return `handoff_status=failure`, `execution_state=failed`, `exit_status=1`, and diagnostics instead of allowing optional adapter failures to crash the Wise command path.

--- a/src/Wise/Cmd/CommandSuggester.php
+++ b/src/Wise/Cmd/CommandSuggester.php
@@ -114,7 +114,7 @@ class CommandSuggester
         }
 
         if (Str::isEmpty($token) || Arr::has($this->verbs, $token, true)) {
-            return Arr::make($this->resources)->slice(0, $limit);
+            return Arr::make($this->resources)->slice(0, $limit)->val();
         }
 
         return $this->rankMatches($token, $this->resources, $limit, 0.4);
@@ -158,6 +158,6 @@ class CommandSuggester
 
         arsort($ranked);
 
-        return Arr::make($ranked)->keys()->slice(0, $limit);
+        return Arr::make($ranked)->keys()->slice(0, $limit)->val();
     }
 }

--- a/src/Wise/Nav/SynthetiqBootstrap.php
+++ b/src/Wise/Nav/SynthetiqBootstrap.php
@@ -95,7 +95,11 @@ class SynthetiqBootstrap
 
         self::emitProgress($progress, 'analyzer', 'Preparing intent analyzer...');
         $analyzer = new KeywordTopicAnalyzer(new NaiveBayesTextClassification, $modelDir);
-        $ai = new SynthetIQ($interpreter, $analyzer);
+        try {
+            $ai = new SynthetIQ($interpreter, $analyzer);
+        } catch (\Throwable $e) {
+            throw new \RuntimeException('Synthetiq runtime is unavailable: ' . $e->getMessage(), 0, $e);
+        }
         self::stabilizePredictors($ai);
 
         $memoryAdapter = $config['memory_adapter'] ?? null;

--- a/src/Wise/Nav/SynthetiqContextHandoff.php
+++ b/src/Wise/Nav/SynthetiqContextHandoff.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace BlueFission\Wise\Nav;
+
+use BlueFission\Arr;
+use BlueFission\Num;
+use BlueFission\Obj;
+use BlueFission\Str;
+use BlueFission\Val;
+
+class SynthetiqContextHandoff extends Obj
+{
+    public const STATUS_ACCEPTED = 'accepted';
+    public const STATUS_REJECTED = 'rejected';
+    public const STATUS_CLARIFICATION = 'clarification';
+    public const STATUS_FAILURE = 'failure';
+
+    private const HANDOFF_FIELDS = [
+        'conversation_profile',
+        'context_refs',
+        'current_intent',
+        'unresolved_questions',
+        'confidence',
+        'declared_capabilities',
+        'provenance',
+        'handoff_status',
+        'diagnostics',
+        'output_id',
+    ];
+
+    private const WISE_ENVELOPE_FIELDS = [
+        'invocation_id',
+        'session_id',
+        'scope',
+        'safety_policy',
+        'execution_state',
+        'waiting_state',
+        'completed_at',
+        'exit_status',
+    ];
+
+    private array $data;
+
+    public function __construct(array $data = [])
+    {
+        parent::__construct();
+        $this->data = self::normalize($data);
+    }
+
+    public static function accepted(array $data = []): self
+    {
+        $data['handoff_status'] = self::STATUS_ACCEPTED;
+
+        return new self($data);
+    }
+
+    public static function failure(string $message, array $data = []): self
+    {
+        $diagnostics = Arr::hasKey($data, 'diagnostics') && Arr::is($data['diagnostics'])
+            ? $data['diagnostics']
+            : [];
+        $diagnostics['message'] = $message;
+
+        $data['diagnostics'] = $diagnostics;
+        $data['handoff_status'] = self::STATUS_FAILURE;
+        $data['execution_state'] = self::stringOrDefault($data, 'execution_state', 'failed');
+        $data['exit_status'] = self::integerOrDefault($data, 'exit_status', 1);
+
+        return new self($data);
+    }
+
+    public static function deterministicFixture(array $overrides = []): self
+    {
+        $fixture = [
+            'conversation_profile' => [
+                'id' => 'wise-fixture-profile',
+                'mode' => 'route-classification',
+            ],
+            'context_refs' => [
+                [
+                    'type' => 'route',
+                    'ref' => 'wise.fixture.route-classification',
+                ],
+            ],
+            'current_intent' => 'wise.route.classify',
+            'unresolved_questions' => [],
+            'confidence' => 1.0,
+            'declared_capabilities' => [],
+            'provenance' => [
+                'source' => 'wise:synthetiq-context-handoff',
+                'fixture' => 'route-classification',
+            ],
+            'handoff_status' => self::STATUS_ACCEPTED,
+            'diagnostics' => [],
+            'invocation_id' => 'wise-fixture-invocation',
+            'session_id' => 'wise-fixture-session',
+            'scope' => 'user',
+            'safety_policy' => 'side_effect_free',
+            'execution_state' => 'completed',
+            'waiting_state' => 'none',
+            'completed_at' => null,
+            'exit_status' => 0,
+        ];
+
+        return new self(Arr::merge($fixture, $overrides));
+    }
+
+    public static function handoffFieldNames(): array
+    {
+        return self::HANDOFF_FIELDS;
+    }
+
+    public static function wiseEnvelopeFieldNames(): array
+    {
+        return self::WISE_ENVELOPE_FIELDS;
+    }
+
+    public function status(): string
+    {
+        return (string)$this->data['handoff_status'];
+    }
+
+    public function outputId(): string
+    {
+        return (string)$this->data['output_id'];
+    }
+
+    public function isAccepted(): bool
+    {
+        return $this->status() === self::STATUS_ACCEPTED;
+    }
+
+    public function toArray(): array
+    {
+        return $this->data;
+    }
+
+    private static function normalize(array $data): array
+    {
+        $status = self::statusOrDefault($data, self::STATUS_ACCEPTED);
+        $normalized = [
+            'conversation_profile' => self::arrayOrDefault($data, 'conversation_profile'),
+            'context_refs' => self::arrayValuesOrDefault($data, 'context_refs'),
+            'current_intent' => self::nullableString($data, 'current_intent'),
+            'unresolved_questions' => self::stringListOrDefault($data, 'unresolved_questions'),
+            'confidence' => self::confidenceOrDefault($data, 'confidence'),
+            'declared_capabilities' => self::stringListOrDefault($data, 'declared_capabilities'),
+            'provenance' => self::arrayOrDefault($data, 'provenance'),
+            'handoff_status' => $status,
+            'diagnostics' => self::arrayOrDefault($data, 'diagnostics'),
+            'output_id' => self::nullableString($data, 'output_id'),
+            'invocation_id' => self::nullableString($data, 'invocation_id'),
+            'session_id' => self::nullableString($data, 'session_id'),
+            'scope' => self::stringOrDefault($data, 'scope', 'global'),
+            'safety_policy' => self::stringOrDefault($data, 'safety_policy', 'side_effect_free'),
+            'execution_state' => self::stringOrDefault($data, 'execution_state', self::executionStateForStatus($status)),
+            'waiting_state' => self::stringOrDefault($data, 'waiting_state', 'none'),
+            'completed_at' => self::nullableString($data, 'completed_at'),
+            'exit_status' => self::integerOrDefault($data, 'exit_status', self::exitStatusForStatus($status)),
+        ];
+
+        if (Str::isEmpty((string)$normalized['output_id'])) {
+            $normalized['output_id'] = self::buildOutputId($normalized);
+        }
+
+        return $normalized;
+    }
+
+    private static function statusOrDefault(array $data, string $default): string
+    {
+        $status = self::stringOrDefault($data, 'handoff_status', $default);
+        $allowed = [
+            self::STATUS_ACCEPTED,
+            self::STATUS_REJECTED,
+            self::STATUS_CLARIFICATION,
+            self::STATUS_FAILURE,
+        ];
+
+        if (!Arr::has($allowed, $status, true)) {
+            return $default;
+        }
+
+        return $status;
+    }
+
+    private static function executionStateForStatus(string $status): string
+    {
+        if ($status === self::STATUS_FAILURE || $status === self::STATUS_REJECTED) {
+            return 'failed';
+        }
+
+        if ($status === self::STATUS_CLARIFICATION) {
+            return 'waiting';
+        }
+
+        return 'completed';
+    }
+
+    private static function exitStatusForStatus(string $status): int
+    {
+        return $status === self::STATUS_ACCEPTED ? 0 : 1;
+    }
+
+    private static function arrayOrDefault(array $data, string $field): array
+    {
+        if (!Arr::hasKey($data, $field) || Val::isNull($data[$field])) {
+            return [];
+        }
+
+        if (Arr::is($data[$field])) {
+            return $data[$field];
+        }
+
+        return [$data[$field]];
+    }
+
+    private static function arrayValuesOrDefault(array $data, string $field): array
+    {
+        return Arr::make(self::arrayOrDefault($data, $field))->values()->val();
+    }
+
+    private static function stringListOrDefault(array $data, string $field): array
+    {
+        return Arr::make(self::arrayOrDefault($data, $field))
+            ->filter(fn($value) => Val::is($value) && !Str::isEmpty((string)$value))
+            ->map(fn($value) => Str::make((string)$value)->trim()->val())
+            ->values()
+            ->unique()
+            ->val();
+    }
+
+    private static function confidenceOrDefault(array $data, string $field): ?float
+    {
+        if (!Arr::hasKey($data, $field) || Val::isNull($data[$field])) {
+            return null;
+        }
+
+        $confidence = Num::make((float)$data[$field])->max(0.0);
+
+        return (float)Num::make($confidence)->min(1.0);
+    }
+
+    private static function nullableString(array $data, string $field): ?string
+    {
+        if (!Arr::hasKey($data, $field) || Val::isNull($data[$field])) {
+            return null;
+        }
+
+        $value = Str::make((string)$data[$field])->trim()->val();
+
+        return Str::isEmpty($value) ? null : $value;
+    }
+
+    private static function stringOrDefault(array $data, string $field, string $default): string
+    {
+        $value = self::nullableString($data, $field);
+
+        return Val::isNull($value) ? $default : $value;
+    }
+
+    private static function integerOrDefault(array $data, string $field, int $default): int
+    {
+        if (!Arr::hasKey($data, $field) || Val::isNull($data[$field])) {
+            return $default;
+        }
+
+        return (int)$data[$field];
+    }
+
+    private static function buildOutputId(array $data): string
+    {
+        $seed = $data;
+        $seed['output_id'] = null;
+
+        return 'wise-out-' . Str::sub(sha1(json_encode($seed, JSON_UNESCAPED_SLASHES)), 0, 16);
+    }
+}

--- a/src/Wise/Nav/SynthetiqProxy.php
+++ b/src/Wise/Nav/SynthetiqProxy.php
@@ -2,6 +2,10 @@
 
 namespace BlueFission\Wise\Nav;
 
+use BlueFission\Arr;
+use BlueFission\Str;
+use BlueFission\Val;
+
 class SynthetiqProxy implements INavigator
 {
     protected object $_synthetiq;
@@ -20,6 +24,34 @@ class SynthetiqProxy implements INavigator
         return (string)$this->_synthetiq->processInput($input);
     }
 
+    public function handoff(string $input, array $context = []): SynthetiqContextHandoff
+    {
+        try {
+            $result = $this->_synthetiq->processInput($input);
+        } catch (\Throwable $e) {
+            return SynthetiqContextHandoff::failure($e->getMessage(), Arr::merge($context, [
+                'diagnostics' => [
+                    'source' => 'synthetiq.processInput',
+                    'exception' => get_class($e),
+                ],
+            ]));
+        }
+
+        $payload = Arr::is($result) ? $result : ['response' => (string)$result];
+        $handoff = Arr::merge($payload, $context);
+        $handoff['handoff_status'] = $handoff['handoff_status'] ?? SynthetiqContextHandoff::STATUS_ACCEPTED;
+        $handoff['provenance'] = Arr::merge(
+            Arr::hasKey($handoff, 'provenance') && Arr::is($handoff['provenance']) ? $handoff['provenance'] : [],
+            ['source' => 'synthetiq.processInput']
+        );
+        $handoff['diagnostics'] = Arr::merge(
+            Arr::hasKey($handoff, 'diagnostics') && Arr::is($handoff['diagnostics']) ? $handoff['diagnostics'] : [],
+            ['response_preview' => self::responsePreview($payload)]
+        );
+
+        return new SynthetiqContextHandoff($handoff);
+    }
+
     public function addRoute(string $statement, string $type, array|string $to = []): void
     {
         if (!method_exists($this->_synthetiq, 'addRoute')) {
@@ -36,5 +68,15 @@ class SynthetiqProxy implements INavigator
         }
 
         $this->_synthetiq->addIntentKeywords($type, $keywords, $priorityBase);
+    }
+
+    private static function responsePreview(array $payload): ?string
+    {
+        $response = $payload['response'] ?? $payload['output'] ?? $payload['message'] ?? null;
+        if (!Val::is($response)) {
+            return null;
+        }
+
+        return Str::make((string)$response)->trim()->truncate(120)->val();
     }
 }

--- a/src/Wise/Sys/Memory/ArrayHoloscene.php
+++ b/src/Wise/Sys/Memory/ArrayHoloscene.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace BlueFission\Wise\Sys\Memory;
+
+class ArrayHoloscene
+{
+    private array $episodes = [];
+
+    public function push(string $episodeId, array $statements): void
+    {
+        $this->episodes[$episodeId] = $statements;
+    }
+
+    public function contents(): array
+    {
+        return $this->episodes;
+    }
+}

--- a/src/Wise/Sys/Memory/ArrayMemoryGraph.php
+++ b/src/Wise/Sys/Memory/ArrayMemoryGraph.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace BlueFission\Wise\Sys\Memory;
+
+use BlueFission\Arr;
+use BlueFission\Automata\Context;
+use BlueFission\Str;
+
+class ArrayMemoryGraph
+{
+    private array $nodes = [];
+
+    public function addMemory(string $label, Context $context, array $edges = []): void
+    {
+        $this->nodes[$label] = new ArrayMemoryNode($context, $edges);
+    }
+
+    public function contents(): array
+    {
+        return $this->nodes;
+    }
+
+    public function forget(string $label): void
+    {
+        unset($this->nodes[$label]);
+    }
+
+    public function recallSimilar(Context $query, float $threshold = 0.0): array
+    {
+        $input = Str::make((string)$query->get('input', ''))->lower()->trim()->val();
+        $results = [];
+
+        foreach ($this->nodes as $label => $node) {
+            $context = $node->getContext();
+            $candidate = self::contextText($context);
+            $score = self::similarity($input, $candidate);
+
+            if ($score < $threshold) {
+                continue;
+            }
+
+            $results[$label] = [
+                'context' => $context,
+                'similarity' => $score,
+                'edges' => $node->getEdges(),
+            ];
+        }
+
+        uasort($results, static fn($a, $b) => $b['similarity'] <=> $a['similarity']);
+
+        return $results;
+    }
+
+    private static function contextText(Context $context): string
+    {
+        $values = [
+            $context->get('input', ''),
+            $context->get('response', ''),
+            $context->get('value', ''),
+            $context->get('label', ''),
+        ];
+
+        return Arr::make($values)
+            ->filter(fn($value) => !Str::isEmpty((string)$value))
+            ->map(fn($value) => Str::make((string)$value)->lower()->trim()->val())
+            ->join(' ')
+            ->val();
+    }
+
+    private static function similarity(string $input, string $candidate): float
+    {
+        if (Str::isEmpty($input) || Str::isEmpty($candidate)) {
+            return 0.0;
+        }
+
+        if (Str::has($candidate, $input) || Str::has($input, $candidate)) {
+            return 1.0;
+        }
+
+        similar_text($input, $candidate, $percent);
+
+        return $percent / 100;
+    }
+}

--- a/src/Wise/Sys/Memory/ArrayMemoryNode.php
+++ b/src/Wise/Sys/Memory/ArrayMemoryNode.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace BlueFission\Wise\Sys\Memory;
+
+use BlueFission\Automata\Context;
+
+class ArrayMemoryNode
+{
+    private Context $context;
+    private array $edges;
+
+    public function __construct(Context $context, array $edges = [])
+    {
+        $this->context = $context;
+        $this->edges = $edges;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context;
+    }
+
+    public function setContext(Context $context): void
+    {
+        $this->context = $context;
+    }
+
+    public function getEdges(): array
+    {
+        return $this->edges;
+    }
+}

--- a/src/Wise/Sys/Memory/ArrayMemoryWorkspace.php
+++ b/src/Wise/Sys/Memory/ArrayMemoryWorkspace.php
@@ -3,42 +3,38 @@
 namespace BlueFission\Wise\Sys\Memory;
 
 use BlueFission\Arr;
-use BlueFission\Automata\Comprehension\Holoscene;
 use BlueFission\Automata\Context;
-use BlueFission\Automata\Memory\Abs2Memory;
 use BlueFission\Num;
 use BlueFission\Str;
 use BlueFission\Val;
 
-class MemoryPartition implements IMemoryWorkspace
+class ArrayMemoryWorkspace implements IMemoryWorkspace
 {
     protected object $_reader;
-    protected object $_memory;
-    protected object $_holoscene;
+    protected ArrayMemoryGraph $_memory;
+    protected ArrayHoloscene $_holoscene;
     protected ?int $_maxSize = null;
     protected float $_decayRate = 3600.0;
 
-    public function __construct(object $reader, ?Abs2Memory $memory = null, ?Holoscene $holoscene = null)
+    public function __construct(object $reader, ?ArrayMemoryGraph $memory = null, ?ArrayHoloscene $holoscene = null)
     {
         if (!method_exists($reader, 'readDocument') || !method_exists($reader, 'toHoloscene')) {
             throw new \InvalidArgumentException('Reader must implement readDocument() and toHoloscene().');
         }
 
         $this->_reader = $reader;
-        $this->_memory = $memory ?? self::makeMemoryGraph();
-        $this->_holoscene = $holoscene ?? self::makeHoloscene();
+        $this->_memory = $memory ?? new ArrayMemoryGraph();
+        $this->_holoscene = $holoscene ?? new ArrayHoloscene();
     }
 
     public function record(string $text, string $episodeId): void
     {
         $statements = $this->_reader->readDocument($text);
-        if ($this->_memory instanceof ArrayMemoryGraph || $this->_holoscene instanceof ArrayHoloscene) {
+        try {
+            $this->_reader->toHoloscene($statements, $this->_holoscene, $this->_memory, $episodeId);
+        } catch (\Throwable $e) {
             $this->recordFallbackStatements($statements, $episodeId);
-            $this->applyRetention();
-            return;
         }
-
-        $this->_reader->toHoloscene($statements, $this->_holoscene, $this->_memory, $episodeId);
         $this->applyRetention();
     }
 
@@ -50,6 +46,7 @@ class MemoryPartition implements IMemoryWorkspace
             $timestamp = $now;
             $context->set('timestamp', $timestamp);
         }
+
         $lastSeen = (int)$context->get('last_seen', 0);
         if ($lastSeen <= 0) {
             $context->set('last_seen', $timestamp);
@@ -81,7 +78,9 @@ class MemoryPartition implements IMemoryWorkspace
 
     public function setDecayRate(float $seconds): void
     {
-        $this->_decayRate = $seconds > 0 ? $seconds : $this->_decayRate;
+        if ($seconds > 0) {
+            $this->_decayRate = $seconds;
+        }
     }
 
     protected function applyRetention(): void
@@ -111,9 +110,7 @@ class MemoryPartition implements IMemoryWorkspace
             $connections = Arr::count($node->getEdges());
             $ageSeconds = Num::make($now - $lastSeen)->max(0);
             $agePenalty = $ageSeconds / $this->_decayRate;
-            $score = $reinforcement + $connections - $agePenalty;
-
-            $scored[$label] = $score;
+            $scored[$label] = $reinforcement + $connections - $agePenalty;
         }
 
         arsort($scored);
@@ -126,25 +123,7 @@ class MemoryPartition implements IMemoryWorkspace
         }
     }
 
-    private static function makeMemoryGraph(): object
-    {
-        try {
-            return new Abs2Memory();
-        } catch (\Throwable $e) {
-            return new ArrayMemoryGraph();
-        }
-    }
-
-    private static function makeHoloscene(): object
-    {
-        try {
-            return new Holoscene();
-        } catch (\Throwable $e) {
-            return new ArrayHoloscene();
-        }
-    }
-
-    private function recordFallbackStatements(array $statements, string $episodeId): void
+    protected function recordFallbackStatements(array $statements, string $episodeId): void
     {
         foreach ($statements as $index => $statement) {
             $context = new Context();

--- a/src/Wise/Sys/Memory/IMemoryWorkspace.php
+++ b/src/Wise/Sys/Memory/IMemoryWorkspace.php
@@ -2,9 +2,7 @@
 
 namespace BlueFission\Wise\Sys\Memory;
 
-use BlueFission\Automata\Comprehension\Holoscene;
 use BlueFission\Automata\Context;
-use BlueFission\Automata\Memory\Abs2Memory;
 
 interface IMemoryWorkspace
 {
@@ -12,9 +10,9 @@ interface IMemoryWorkspace
 
     public function recordContext(Context $context, string $label, array $edges = []): void;
 
-    public function memory(): Abs2Memory;
+    public function memory(): object;
 
-    public function holoscene(): Holoscene;
+    public function holoscene(): object;
 
     public function setMaxSize(?int $maxSize): void;
 

--- a/src/Wise/Sys/Memory/WorkingMemoryCoordinator.php
+++ b/src/Wise/Sys/Memory/WorkingMemoryCoordinator.php
@@ -139,6 +139,10 @@ class WorkingMemoryCoordinator
             }
         }
 
-        return new MemoryPartition($this->_reader);
+        try {
+            return new MemoryPartition($this->_reader);
+        } catch (\Throwable $e) {
+            return new ArrayMemoryWorkspace($this->_reader);
+        }
     }
 }

--- a/tests/SynthetiqBootstrapTest.php
+++ b/tests/SynthetiqBootstrapTest.php
@@ -18,6 +18,7 @@ final class SynthetiqBootstrapTest extends TestCase
         if (!DirectoryManager::pathExists($vendorPath)) {
             $this->markTestSkipped('Synthetiq sample configs not available.');
         }
+        $this->skipIfSynthetiqRuntimeUnavailable();
 
         $modelPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'wise-synthetiq-models';
 
@@ -36,6 +37,7 @@ final class SynthetiqBootstrapTest extends TestCase
         if (!DirectoryManager::pathExists($vendorPath)) {
             $this->markTestSkipped('Synthetiq sample configs not available.');
         }
+        $this->skipIfSynthetiqRuntimeUnavailable();
 
         $config = [
             'dialogue' => [
@@ -73,6 +75,7 @@ final class SynthetiqBootstrapTest extends TestCase
         if (!DirectoryManager::pathExists($vendorPath)) {
             $this->markTestSkipped('Synthetiq sample configs not available.');
         }
+        $this->skipIfSynthetiqRuntimeUnavailable();
 
         $config = [
             'dialogue' => require $vendorPath . DIRECTORY_SEPARATOR . 'dialogue.php',
@@ -97,5 +100,38 @@ final class SynthetiqBootstrapTest extends TestCase
 
         $this->assertIsString($response);
         $this->assertNotSame('', $response);
+    }
+
+    public function testBootstrapReportsUnavailablePartialRuntime(): void
+    {
+        if (class_exists('BlueFission\\Chronicler\\Storage\\Structures\\WeightedCollection')) {
+            $this->markTestSkipped('Synthetiq runtime is complete in this environment.');
+        }
+
+        $vendorPath = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'bluefission' . DIRECTORY_SEPARATOR . 'synthetiq' . DIRECTORY_SEPARATOR . 'sample_configs';
+        if (!DirectoryManager::pathExists($vendorPath)) {
+            $this->markTestSkipped('Synthetiq sample configs not available.');
+        }
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Synthetiq runtime is unavailable');
+
+        SynthetiqBootstrap::fromConfig([
+            'dialogue' => [
+                'wise.test.intent' => ['wise.test.intent', ['wise test response'], ['wise-intent']],
+            ],
+            'intent_boosts' => [],
+            'grammar' => require $vendorPath . DIRECTORY_SEPARATOR . 'grammar.php',
+            'tokens' => require $vendorPath . DIRECTORY_SEPARATOR . 'tokens.php',
+            'documenter' => require $vendorPath . DIRECTORY_SEPARATOR . 'documenter.php',
+            'model_path' => sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'wise-synthetiq-models-unavailable',
+        ]);
+    }
+
+    private function skipIfSynthetiqRuntimeUnavailable(): void
+    {
+        if (!class_exists('BlueFission\\Chronicler\\Storage\\Structures\\WeightedCollection')) {
+            $this->markTestSkipped('Synthetiq runtime dependency graph is incomplete.');
+        }
     }
 }

--- a/tests/SynthetiqContextHandoffTest.php
+++ b/tests/SynthetiqContextHandoffTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace BlueFission\Tests;
+
+use BlueFission\Arr;
+use BlueFission\Wise\Nav\SynthetiqContextHandoff;
+use BlueFission\Wise\Nav\SynthetiqProxy;
+use PHPUnit\Framework\TestCase;
+
+final class SynthetiqContextHandoffTest extends TestCase
+{
+    public function testDeterministicFixtureDeclaresWiseAndSynthetiqFields(): void
+    {
+        $first = SynthetiqContextHandoff::deterministicFixture();
+        $second = SynthetiqContextHandoff::deterministicFixture();
+        $payload = $first->toArray();
+
+        $this->assertTrue($first->isAccepted());
+        $this->assertSame($first->outputId(), $second->outputId());
+        $this->assertSame([], $payload['declared_capabilities']);
+        $this->assertSame('wise.route.classify', $payload['current_intent']);
+        $this->assertSame('side_effect_free', $payload['safety_policy']);
+        $this->assertSame(0, $payload['exit_status']);
+
+        foreach (SynthetiqContextHandoff::handoffFieldNames() as $field) {
+            $this->assertTrue(Arr::hasKey($payload, $field), "Missing handoff field {$field}");
+        }
+
+        foreach (SynthetiqContextHandoff::wiseEnvelopeFieldNames() as $field) {
+            $this->assertTrue(Arr::hasKey($payload, $field), "Missing Wise envelope field {$field}");
+        }
+    }
+
+    public function testProxyBuildsAcceptedHandoffFromSideEffectFreeRouteClassification(): void
+    {
+        $synthetiq = new class {
+            public function processInput(string $input): array
+            {
+                return [
+                    'response' => 'route accepted for ' . $input,
+                    'current_intent' => 'wise.route.classify',
+                    'confidence' => 1.5,
+                ];
+            }
+        };
+
+        $handoff = (new SynthetiqProxy($synthetiq))->handoff('list all resources', [
+            'conversation_profile' => ['id' => 'operator'],
+            'context_refs' => [['type' => 'route', 'ref' => 'wise.resources']],
+            'declared_capabilities' => [],
+            'session_id' => 'session-1',
+            'scope' => 'user',
+            'safety_policy' => 'side_effect_free',
+        ]);
+        $payload = $handoff->toArray();
+
+        $this->assertSame(SynthetiqContextHandoff::STATUS_ACCEPTED, $handoff->status());
+        $this->assertSame(1.0, $payload['confidence']);
+        $this->assertSame([], $payload['declared_capabilities']);
+        $this->assertSame('synthetiq.processInput', $payload['provenance']['source']);
+        $this->assertSame('route accepted for list all resources', $payload['diagnostics']['response_preview']);
+        $this->assertMatchesRegularExpression('/^wise-out-[a-f0-9]{16}$/', $payload['output_id']);
+    }
+
+    public function testProxyBuildsFailureHandoffForUnavailableRuntime(): void
+    {
+        $synthetiq = new class {
+            public function processInput(string $input): string
+            {
+                throw new \RuntimeException('classifier unavailable');
+            }
+        };
+
+        $payload = (new SynthetiqProxy($synthetiq))
+            ->handoff('list all resources', ['session_id' => 'session-1'])
+            ->toArray();
+
+        $this->assertSame(SynthetiqContextHandoff::STATUS_FAILURE, $payload['handoff_status']);
+        $this->assertSame('failed', $payload['execution_state']);
+        $this->assertSame(1, $payload['exit_status']);
+        $this->assertSame('classifier unavailable', $payload['diagnostics']['message']);
+        $this->assertSame('RuntimeException', $payload['diagnostics']['exception']);
+    }
+}


### PR DESCRIPTION
## Intent summary

Add the Wise-side Synthetiq conversational context handoff contract and keep Synthetiq optional when its upstream runtime graph is incomplete.

## User stories / acceptance criteria

- As Wise, I can expose a stable Synthetiq handoff with conversation_profile, context_refs, current_intent, unresolved_questions, confidence, declared_capabilities, provenance, handoff_status, diagnostics, and output_id.
- As Wise, I keep invocation, session, scope, safety, execution, waiting, completion, and exit-status fields under Wise ownership.
- As a CLI user, partial Synthetiq/Automata runtime availability returns structured diagnostics or a deterministic fallback instead of fataling.
- As a contributor, command suggestions return plain arrays at method boundaries while still using DevElation primitives internally.

## Key files changed

- src/Wise/Nav/SynthetiqContextHandoff.php
- src/Wise/Nav/SynthetiqProxy.php
- src/Wise/Nav/SynthetiqBootstrap.php
- src/Wise/Sys/Memory/ArrayMemoryWorkspace.php and related fallback memory classes
- src/Wise/Sys/Memory/MemoryPartition.php
- src/Wise/Cmd/CommandSuggester.php
- tests/SynthetiqContextHandoffTest.php
- tests/SynthetiqBootstrapTest.php
- docs/synthetiq-context-handoff.md

## How to test

- php -l src/Wise/Nav/SynthetiqContextHandoff.php
- php -l src/Wise/Nav/SynthetiqProxy.php
- php -l src/Wise/Nav/SynthetiqBootstrap.php
- php -l src/Wise/Sys/Memory/ArrayMemoryWorkspace.php
- php -l src/Wise/Sys/Memory/MemoryPartition.php
- php -l src/Wise/Cmd/CommandSuggester.php
- vendor/bin/phpunit --do-not-cache-result tests/SynthetiqContextHandoffTest.php tests/SynthetiqProxyTest.php tests/SynthetiqBootstrapTest.php tests/WorkingMemoryCoordinatorTest.php tests/Sys/Memory/MemoryPartitionTest.php tests/Sys/Memory/SynthetiqMemoryAdapterTest.php
- vendor/bin/phpunit --do-not-cache-result tests/Cmd/CommandSuggesterTest.php tests/Cli/ReplKeyInputTest.php tests/Cli/TerminalScriptInteractionTest.php tests/WorkingMemoryCoordinatorTest.php tests/Sys/Memory/MemoryPartitionTest.php tests/Sys/Memory/SynthetiqMemoryAdapterTest.php
- vendor/bin/phpunit --do-not-cache-result

## QA checklist

- Full PHPUnit suite passes: 151 tests, 364 assertions, 1 expected optional-runtime skip, 6 PHPUnit deprecations.
- Synthetiq direct coordination accepted the field vocabulary and confirmed no new room is needed.
- Composer dependency refresh for released packages was attempted but blocked by resolver access; that remains tracked separately in #23.
- No secrets or environment files changed.

## Approval conditions

- Confirm the handoff field vocabulary is acceptable for Wise #15.
- Confirm the fallback memory workspace is acceptable when upstream Automata/Synthetiq memory dependencies are partially installed.
- Keep Composer release-constraint solving separate under #23.
