### PR TITLE
Align released Composer dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+          - '8.2'
+          - '8.3'
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: composer:v2
+
+      - name: Validate Composer manifest
+        run: composer validate --strict --no-check-lock
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Check platform requirements
+        run: composer check-platform-reqs
+
+      - name: Run test suite
+        run: vendor/bin/phpunit --do-not-cache-result

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
   test:
     name: PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
+    env:
+      GH_REPO_TOKEN: ${{ secrets.BF_GITHUB_TOKEN != '' && secrets.BF_GITHUB_TOKEN || secrets.CI_GITHUB_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -26,7 +28,16 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Sanitize GitHub authentication
+        run: |
+          git config --local --unset-all http.https://github.com/.extraheader || true
+          git config --local --unset-all credential.helper || true
+          git config --global --unset-all http.https://github.com/.extraheader || true
+          git config --global --unset-all credential.helper || true
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -38,8 +49,17 @@ jobs:
       - name: Validate Composer manifest
         run: composer validate --strict --no-check-lock
 
+      - name: Check private dependency access
+        run: |
+          if [ -z "${GH_REPO_TOKEN:-}" ]; then
+            echo "::error::Set BF_GITHUB_TOKEN or CI_GITHUB_TOKEN so Composer can install private dependencies."
+            exit 1
+          fi
+
       - name: Install dependencies
-        run: composer install --no-interaction --no-progress --prefer-dist
+        run: |
+          export COMPOSER_AUTH="{\"github-oauth\":{\"github.com\":\"${GH_REPO_TOKEN}\"}}"
+          composer install --no-interaction --no-progress --prefer-dist
 
       - name: Check platform requirements
         run: composer check-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -15,22 +15,6 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/bluefissiontech/develation"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/bluefissiontech/automata"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/bluefissiontech/simpleclients"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/bluefissiontech/synthetiq"
-        },
-        {
-            "type": "vcs",
             "url": "https://github.com/bluefissiontech/bluecore"
         },
         {
@@ -45,9 +29,9 @@
     "minimum-stability": "dev",
     "require": {
         "bluefission/develation": "^1.3.41",
-        "bluefission/automata": "dev-master as 1.0.0-alpha.2",
-        "bluefission/simpleclients": "dev-master",
-        "bluefission/synthetiq": "dev-main",
+        "bluefission/automata": "^1.0.0-alpha.2",
+        "bluefission/simpleclients": "^0.1.0-alpha",
+        "bluefission/synthetiq": "^0.1.0-alpha",
         "bluefission/jenerator": "dev-main",
         "bluefission/vibrato": "dev-main",
         "google/cloud-language": "^0.27.0",

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,6 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/bluefissiontech/bluecore"
-        },
-        {
-            "type": "vcs",
             "url": "https://github.com/bluefissiontech/jenerator"
         },
         {

--- a/tests/Cli/TerminalScriptInteractionTest.php
+++ b/tests/Cli/TerminalScriptInteractionTest.php
@@ -103,6 +103,7 @@ final class TerminalScriptInteractionTest extends TestCase
         $stderr = '';
         $deadline = microtime(true) + 15;
         $timedOut = false;
+        $exitCode = -1;
 
         while (true) {
             $stdout .= stream_get_contents($pipes[1]) ?: '';
@@ -110,6 +111,7 @@ final class TerminalScriptInteractionTest extends TestCase
 
             $status = proc_get_status($process);
             if (!$status['running']) {
+                $exitCode = $status['exitcode'];
                 break;
             }
 
@@ -127,7 +129,10 @@ final class TerminalScriptInteractionTest extends TestCase
 
         fclose($pipes[1]);
         fclose($pipes[2]);
-        $exitCode = proc_close($process);
+        $closeExitCode = proc_close($process);
+        if ($exitCode < 0) {
+            $exitCode = $closeExitCode;
+        }
 
         if ($timedOut) {
             $this->fail('Wise CLI process timed out. stdout: ' . $stdout . ' stderr: ' . $stderr);


### PR DESCRIPTION
## Intent

Align Wise with published Materia package releases, retain explicit VCS routing only for unreleased interpreter packages, and prove the complete dependency graph from clean PHP environments.

Closes #23.

## User Stories / Acceptance Criteria

- As a package consumer, I can resolve released DevElation, Automata, SimpleClients, Synthetiq, and BlueCore versions through Packagist.
- Automata, SimpleClients, Synthetiq, and BlueCore use tagged alpha releases instead of development aliases.
- Root repository entries remain only for packages that are not yet available through Packagist.
- Private VCS dependencies install through a repository-scoped, read-only CI credential.
- The full Wise suite and PHP platform checks pass with the current upstream graph.

## Upstream Contract

- Jenerator remains on `dev-main` until its tagged Packagist release is available.
- Jenerator `main` is verified at `1104094715fa49e737bd93c6343642fd5ed76c40`.
- That revision requires PHP `>=8.2`, DevElation `^1.3.39`, and Automata `^1.0.0-alpha.3`, which are compatible with Wise's constraints.
- Vibrato `main` is verified at `562190fef3adaca3d8018acda70c16dbf446d920`.
- Vibrato now requires BlueCore `^0.1.0@alpha` and no longer declares a BlueCore VCS source.
- BlueCore `v0.1.0-alpha` resolves from Packagist at `1060f78f75ae0932f6cca14e9a972b1c1fae4313`.

## Key Files

- `composer.json`: removes published-package VCS overrides and adopts released constraints.
- `.github/workflows/ci.yml`: validates clean PHP 8.2/8.3 installs with scoped private-repository access.
- `tests/Cli/TerminalScriptInteractionTest.php`: preserves child exit status consistently across supported PHP versions.

## How To Test

```shell
composer validate --strict --no-check-lock
composer check-platform-reqs
vendor/bin/phpunit --do-not-cache-result
git diff --check origin/main...HEAD
```

## QA Checklist

- [x] DevElation resolves at v1.3.41.
- [x] Automata resolves at v1.0.0-alpha.3.
- [x] Chronicler resolves at v0.1.2-alpha.
- [x] SimpleClients resolves at v0.1.0-alpha.
- [x] Synthetiq resolves at v0.1.0-alpha.
- [x] BlueCore resolves from Packagist at v0.1.0-alpha / `1060f78`.
- [x] Jenerator resolves at `1104094`.
- [x] Vibrato resolves at `562190f` with the released BlueCore constraint.
- [x] Platform requirements pass on PHP 8.2.
- [x] PHPUnit passes locally: 184 tests, 428 assertions, one expected skip.
- [x] No local path repositories are present in the tracked manifest.
- [x] No published package retains a root VCS override.
- [x] Private dependency access is limited to read-only contents and metadata for the required repositories.

## Approval Conditions

- CI confirms canonical Packagist and VCS resolution from clean PHP 8.2 and 8.3 environments against Jenerator `1104094` and Vibrato `562190f` or newer.
- Composer validation and the full test suite remain green.
- Review confirms the only remaining root VCS entries are the unreleased Jenerator and Vibrato packages.
