### PR TITLE
Add Wise-owned resource storage root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,7 @@ logs
 # Ignore the script output files
 /speech.mp3
 /speech.wav
+/storage/
 # Blue Fission Codex harness
 /docker/
 /scripts/

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1,0 +1,9 @@
+# Resource Storage
+
+Wise stores persisted resource data under `storage/` in the current workspace by default. Set `WISE_STORAGE_ROOT` to an explicit directory when the shell should use another location:
+
+```bash
+WISE_STORAGE_ROOT=/var/lib/wise php terminal.php
+```
+
+Hosts can also inject a `BlueFission\Wise\Sys\StorageRoot` into resource constructors. The legacy `OPUS_ROOT` constant remains supported as a compatibility fallback and resolves to its `storage/` directory, but new integrations should use the Wise-owned environment or object contract.

--- a/src/Wise/Prg/WebBrowser.php
+++ b/src/Wise/Prg/WebBrowser.php
@@ -3,15 +3,23 @@
 // WebBrowser.php
 namespace BlueFission\Wise\Prg;
 
+use BlueFission\Connections\Curl;
+use BlueFission\Data\FileSystem;
+use BlueFission\Net\HTTP;
 use BlueFission\Services\Service;
+use BlueFission\Str;
+use BlueFission\Wise\Sys\StorageRoot;
 use Symfony\Component\Panther\Client;
 
 class WebBrowser extends Service
 {
     private $client;
+    private StorageRoot $storageRoot;
 
-    public function __construct()
+    public function __construct(?StorageRoot $storageRoot = null)
     {
+        parent::__construct();
+        $this->storageRoot = $storageRoot ?? new StorageRoot();
         $this->client = Client::createChromeClient();
     }
 
@@ -65,20 +73,34 @@ class WebBrowser extends Service
 
     public function downloadMedia(string $url): void
     {
-        // Note: Downloading media files can be a complex task, especially when dealing with different content types and handling large files.
-        // The following is a simple example of downloading a file, but it may not cover all edge cases and may need to be adapted for specific use cases.
-
-        $parsedUrl = parse_url($url);
-        $path = $parsedUrl['path'];
-        $filename = basename($path);
-
-        // Check if the file is downloadable by checking if the header contains 'Content-Disposition' with 'attachment'
-        $headers = get_headers($url, 1);
-        if (isset($headers['Content-Disposition']) && strpos($headers['Content-Disposition'], 'attachment') !== false) {
-            // Download the file using 'file_put_contents' function.
-            // You can change the destination path as needed.
-            file_put_contents(OPUS_ROOT."storage/downloads/{$filename}", fopen($url, 'r'));
+        $path = HTTP::urlPath($url);
+        if (!Str::is($path)) {
+            return;
         }
+
+        $filename = FileSystem::fileBasename($path);
+        if (Str::isEmpty($filename)) {
+            return;
+        }
+
+        $connection = new Curl(['target' => $url, 'method' => 'get']);
+        $connection->open()->query();
+        $contents = $connection->result();
+        $connection->close();
+
+        if (!Str::is($contents)) {
+            return;
+        }
+
+        $storage = new FileSystem([
+            'root' => $this->storageRoot->prepare('downloads'),
+            'mode' => 'w+',
+            'filter' => [],
+        ]);
+        $storage->open($filename);
+        $storage->contents($contents);
+        $storage->write();
+        $storage->close();
     }
 
     public function getLinks(string $selector): array

--- a/src/Wise/Res/APIResource.php
+++ b/src/Wise/Res/APIResource.php
@@ -4,7 +4,7 @@ namespace BlueFission\Wise\Res;
 use BlueFission\Wise\Res\BaseResource;
 use BlueFission\SimpleClients\OpenAIClient;
 use BlueFission\Data\Storage\Disk;
-use BlueFission\Wise\Sys\DirectoryManager;
+use BlueFission\Wise\Sys\StorageRoot;
 use \BlueFission\Connections\Curl;
 
 class APIResource extends BaseResource
@@ -14,15 +14,14 @@ class APIResource extends BaseResource
     protected $_name = 'api';
     protected $_actions = ['use', 'create', 'generate', 'list', 'previous', 'next', 'show', 'delete', 'help'];
 
-    public function __construct()
+    public function __construct(?StorageRoot $storageRoot = null)
     {
         $this->_itemName = 'remote call';
         $this->_helpDetails['make'] = ["  - create: Create a new api call with the given name, description, and parameters.", "      Usage: `create api <name> \"<description>\" by <method> at <url> with \"<params>\" \"<code>\"`"];
         $this->_helpDetails['do'] = ["  - use: Invoke the api call with the given name, passing in the specified parameters.", "      Usage: `use the api <api call name> with [\"<parameters>\"...]`"];
-        parent::__construct();
+        parent::__construct($storageRoot);
 
-        $storagePath = OPUS_ROOT . '/storage/system';
-        DirectoryManager::ensurePath($storagePath);
+        $storagePath = $this->storagePath();
         $this->_storage = new Disk([
             'location' => $storagePath,
             'name' => "{$this->_location}.json",

--- a/src/Wise/Res/ActionResource.php
+++ b/src/Wise/Res/ActionResource.php
@@ -4,7 +4,7 @@ namespace BlueFission\Wise\Res;
 use BlueFission\Wise\Res\BaseResource;
 use BlueFission\SimpleClients\OpenAIClient;
 use BlueFission\Data\Storage\Disk;
-use BlueFission\Wise\Sys\DirectoryManager;
+use BlueFission\Wise\Sys\StorageRoot;
 
 class ActionResource extends BaseResource
 {
@@ -13,15 +13,14 @@ class ActionResource extends BaseResource
     protected $_name = 'action';
     protected $_actions = ['run', 'create', 'generate', 'list', 'previous', 'next', 'show', 'delete', 'help'];
 
-    public function __construct()
+    public function __construct(?StorageRoot $storageRoot = null)
     {
         $this->_itemName = 'function';
         $this->_helpDetails['make'] = ["  - create: Create a new function with the given name, description, fields, and PHP code.", "      Usage: `create an action <name> that \"<description>\" with \"<jsonFormattedFields>\" by \"<code>\"`"];
         $this->_helpDetails['do'] = ["  - run: Execute the function with the given name, passing in the specified arguments.", "      Usage: `run the action <function name> with [\"<arguments>\"...]`"];
-        parent::__construct();
+        parent::__construct($storageRoot);
 
-        $storagePath = OPUS_ROOT . '/storage/system';
-        DirectoryManager::ensurePath($storagePath);
+        $storagePath = $this->storagePath();
         $this->_storage = new Disk([
             'location' => $storagePath,
             'name' => "{$this->_location}.json",

--- a/src/Wise/Res/BaseResource.php
+++ b/src/Wise/Res/BaseResource.php
@@ -9,8 +9,10 @@ use BlueFission\Num;
 use BlueFission\Services\Service;
 use BlueFission\Str;
 use BlueFission\Val;
+use BlueFission\Wise\Sys\StorageRoot;
 
 abstract class BaseResource extends Service {
+    protected StorageRoot $_storageRoot;
     protected $_entries = [];
     protected $_selected = null;
     protected $_page;
@@ -40,8 +42,9 @@ abstract class BaseResource extends Service {
     protected int $_outputPreviewChars = 240;
     protected int $_outputFullMax = 2000;
 
-	public function __construct( )
+	public function __construct(?StorageRoot $storageRoot = null)
 	{
+        $this->_storageRoot = $storageRoot ?? new StorageRoot();
         $this->_location = $this->_location ?? "{$this->_name}_data";
         $this->_page = (int)store("_system.{$this->_name}.page");
         $this->_perPage = (int)store("_system.{$this->_name}.per_page");
@@ -59,6 +62,11 @@ abstract class BaseResource extends Service {
 
 		parent::__construct();
 	}
+
+    protected function storagePath(string $scope = 'system'): string
+    {
+        return $this->_storageRoot->prepare($scope);
+    }
 
     public function handle($behavior, $args)
     {

--- a/src/Wise/Res/FileResource.php
+++ b/src/Wise/Res/FileResource.php
@@ -3,15 +3,17 @@ namespace BlueFission\Wise\Commands;
 
 use BlueFission\Services\Service;
 use BlueFission\Data\FileSystem;
-use BlueFission\Wise\Sys\DirectoryManager;
+use BlueFission\Wise\Sys\StorageRoot;
 
 class FileResource extends Service {
     private $_fileSystem;
+    private StorageRoot $_storageRoot;
 
-    public function __construct() {
+    public function __construct(?StorageRoot $storageRoot = null) {
         parent::__construct();
+        $this->_storageRoot = $storageRoot ?? new StorageRoot();
         $this->_fileSystem = new FileSystem([
-            'root'=>OPUS_ROOT . 'storage/files',
+            'root'=>$this->_storageRoot->prepare('files'),
             'mode'=>'a+',
             'filter'=>['..', 'txt', 'html', 'json', 'xml', 'csv', 'tsv', 'md', '' ]
         ]);
@@ -71,8 +73,7 @@ class FileResource extends Service {
     }
 
     private function createFilesDirectory() {
-        $path = OPUS_ROOT . '/storage/files';
-        DirectoryManager::ensurePath($path);
+        $this->_storageRoot->prepare('files');
     }
 
     public function help() {
@@ -158,7 +159,7 @@ class FileResource extends Service {
     }
 
     private function listDirectory() {
-        $path = OPUS_ROOT . '/storage/files';
+        $path = $this->_storageRoot->prepare('files');
         $files = scandir($path);
 
         $response = "List of files in the directory:" . PHP_EOL;

--- a/src/Wise/Res/NoteResource.php
+++ b/src/Wise/Res/NoteResource.php
@@ -6,20 +6,21 @@ use BlueFission\BlueCore\Business\Prompts\MakeNote;
 use BlueFission\SimpleClients\OpenAIClient;
 use BlueFission\Data\Storage\Disk;
 use BlueFission\Services\Service;
-use BlueFission\Wise\Sys\DirectoryManager;
+use BlueFission\Wise\Sys\StorageRoot;
 
 class NoteResource extends Service
 {
     private $_storage;
+    private StorageRoot $_storageRoot;
     private $_page = 1;
     private $_perPage = 5;
 
-    public function __construct()
+    public function __construct(?StorageRoot $storageRoot = null)
     {
         parent::__construct();
+        $this->_storageRoot = $storageRoot ?? new StorageRoot();
 
-        $storagePath = OPUS_ROOT . '/storage/system';
-        DirectoryManager::ensurePath($storagePath);
+        $storagePath = $this->_storageRoot->prepare('system');
         $this->_storage = new Disk([
             'location' => $storagePath,
             'name' => 'note_data.json',
@@ -260,7 +261,7 @@ class NoteResource extends Service
 
     private function getCurrentTask()
     {
-        $storagePath = OPUS_ROOT . '/storage/system';
+        $storagePath = $this->_storageRoot->prepare('system');
         
         $storage = new Disk([
             'location' => $storagePath,

--- a/src/Wise/Res/ScheduleResource.php
+++ b/src/Wise/Res/ScheduleResource.php
@@ -4,7 +4,7 @@ namespace BlueFission\Wise\Res;
 
 use BlueFission\Data\Storage\Disk;
 use BlueFission\Services\Service;
-use BlueFission\Wise\Sys\DirectoryManager;
+use BlueFission\Wise\Sys\StorageRoot;
 use DateTime;
 
 class Schedule
@@ -27,11 +27,10 @@ class ScheduleResource extends Service
 {
     protected $_storage;
 
-    public function __construct()
+    public function __construct(?StorageRoot $storageRoot = null)
     {
         parent::__construct();
-        $storagePath = OPUS_ROOT . '/storage/system';
-        DirectoryManager::ensurePath($storagePath);
+        $storagePath = ($storageRoot ?? new StorageRoot())->prepare('system');
         $this->_storage = new Disk([
             'location' => $storagePath,
             'name' => 'schedule_data.json',

--- a/src/Wise/Res/StepResource.php
+++ b/src/Wise/Res/StepResource.php
@@ -7,18 +7,17 @@ use BlueFission\Services\Service;
 use BlueFission\Data\Storage\Disk;
 use BlueFission\Behavioral\IDispatcher;
 use BlueFission\SimpleClients\OpenAIClient;
-use BlueFission\Wise\Sys\DirectoryManager;
+use BlueFission\Wise\Sys\StorageRoot;
 
 class StepResource extends Service {
 
     private $_steps;
     private $_storage;
 
-    public function __construct() {
+    public function __construct(?StorageRoot $storageRoot = null) {
         parent::__construct();
 
-        $storagePath = OPUS_ROOT . '/storage/system';
-        DirectoryManager::ensurePath($storagePath);
+        $storagePath = ($storageRoot ?? new StorageRoot())->prepare('system');
         $this->_storage = new Disk([
             'location' => $storagePath,
             'name' => 'steps_data.json',

--- a/src/Wise/Res/TodoResource.php
+++ b/src/Wise/Res/TodoResource.php
@@ -3,7 +3,7 @@ namespace BlueFission\Wise\Res;
 
 use BlueFission\Wise\Res\BaseResource;
 use BlueFission\Data\Storage\Disk;
-use BlueFission\Wise\Sys\DirectoryManager;
+use BlueFission\Wise\Sys\StorageRoot;
 
 class TodoResource extends BaseResource
 {
@@ -12,14 +12,13 @@ class TodoResource extends BaseResource
     protected $_name = 'todo';
     protected $_actions = ['list', 'make', 'previous', 'next', 'create', 'open', 'edit', 'add', 'select', 'delete', 'search', 'help'];
 
-    public function __construct()
+    public function __construct(?StorageRoot $storageRoot = null)
     {
         $this->_itemName = 'list';
         $this->_subItemName = 'task';
-        parent::__construct();
+        parent::__construct($storageRoot);
 
-        $storagePath = OPUS_ROOT . '/storage/system';
-        DirectoryManager::ensurePath($storagePath);
+        $storagePath = $this->storagePath();
         $this->_storage = new Disk([
             'location' => $storagePath,
             'name' => "{$this->_location}.json",

--- a/src/Wise/Res/VariableResource.php
+++ b/src/Wise/Res/VariableResource.php
@@ -3,7 +3,7 @@ namespace BlueFission\Wise\Res;
 
 use BlueFission\Wise\Res\BaseResource;
 use BlueFission\Data\Storage\Disk;
-use BlueFission\Wise\Sys\DirectoryManager;
+use BlueFission\Wise\Sys\StorageRoot;
 
 class VariableResource extends BaseResource
 {
@@ -13,13 +13,12 @@ class VariableResource extends BaseResource
     protected $_actions = ['get', 'set', 'list', 'show', 'next', 'previous', 'search', 'delete', 'help'];
     protected $_listType;
 
-    public function __construct()
+    public function __construct(?StorageRoot $storageRoot = null)
     {
         $this->_key = null;
-        parent::__construct();
+        parent::__construct($storageRoot);
 
-        $storagePath = OPUS_ROOT . '/storage/system';
-        DirectoryManager::ensurePath($storagePath);
+        $storagePath = $this->storagePath();
         $this->_storage = new Disk([
             'location' => $storagePath,
             'name' => "{$this->_location}.json",

--- a/src/Wise/Sys/StorageRoot.php
+++ b/src/Wise/Sys/StorageRoot.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace BlueFission\Wise\Sys;
+
+use BlueFission\Arr;
+use BlueFission\Behavioral\Behaviors\Event;
+use BlueFission\Behavioral\Behaviors\Meta;
+use BlueFission\Obj;
+use BlueFission\Str;
+use BlueFission\Val;
+use RuntimeException;
+
+class StorageRoot extends Obj
+{
+    public const ENVIRONMENT_KEY = 'WISE_STORAGE_ROOT';
+
+    private Str $root;
+
+    public function __construct(?string $path = null)
+    {
+        parent::__construct();
+        $this->root = Str::make($this->normalize($this->resolve($path)));
+    }
+
+    public function root(): string
+    {
+        return $this->root->val();
+    }
+
+    public function path(string ...$segments): string
+    {
+        $parts = Arr::make([$this->root()]);
+
+        foreach ($segments as $segment) {
+            $segment = Str::make($segment)->trim()->val();
+            if (Str::isEmpty($segment)) {
+                continue;
+            }
+
+            if ($segment === '..' || Str::has($segment, '/') || Str::has($segment, '\\')) {
+                throw new RuntimeException('Storage path segments must be relative names.');
+            }
+
+            $parts->push($segment);
+        }
+
+        return $parts->join(DIRECTORY_SEPARATOR)->val();
+    }
+
+    public function prepare(string ...$segments): string
+    {
+        $path = $this->path(...$segments);
+
+        if (!DirectoryManager::ensurePath($path)
+            || !DirectoryManager::pathIsReachable($path)
+            || !$this->isWritable($path)) {
+            $this->dispatch(Event::FAILURE, new Meta(data: ['path' => $path], src: $this));
+            throw new RuntimeException("Storage path is unavailable: {$path}");
+        }
+
+        $this->dispatch(Event::SUCCESS, new Meta(data: ['path' => $path], src: $this));
+
+        return $path;
+    }
+
+    protected function isWritable(string $path): bool
+    {
+        // DevElation currently exposes directory readability but not writability.
+        return is_writable($path);
+    }
+
+    private function resolve(?string $path): string
+    {
+        if (Val::isNotNull($path) && Str::isNotEmpty($path)) {
+            return $path;
+        }
+
+        $configured = env(self::ENVIRONMENT_KEY);
+        if (Str::is($configured) && Str::isNotEmpty($configured)) {
+            return $configured;
+        }
+
+        if (defined('OPUS_ROOT')) {
+            return Arr::make([(string)constant('OPUS_ROOT'), 'storage'])
+                ->join(DIRECTORY_SEPARATOR)
+                ->val();
+        }
+
+        return 'storage';
+    }
+
+    private function normalize(string $path): string
+    {
+        $path = Str::make($path)
+            ->trim()
+            ->replace('/', DIRECTORY_SEPARATOR)
+            ->replace('\\', DIRECTORY_SEPARATOR)
+            ->val();
+
+        if (Str::isEmpty($path) || Str::has($path, "\0")) {
+            throw new RuntimeException('Storage root must be a valid path.');
+        }
+
+        $segments = Str::make($path)->split(DIRECTORY_SEPARATOR);
+        if ($segments->has('..')) {
+            throw new RuntimeException('Storage root cannot traverse parent directories.');
+        }
+
+        $trimmed = rtrim($path, DIRECTORY_SEPARATOR);
+
+        return $trimmed === '' ? DIRECTORY_SEPARATOR : $trimmed;
+    }
+}

--- a/tests/Res/ResourceStorageRootTest.php
+++ b/tests/Res/ResourceStorageRootTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace BlueFission\Tests\Res;
+
+use BlueFission\Wise\Commands\FileResource;
+use BlueFission\Wise\Res\ActionResource;
+use BlueFission\Wise\Res\APIResource;
+use BlueFission\Wise\Res\NoteResource;
+use BlueFission\Wise\Res\ScheduleResource;
+use BlueFission\Wise\Res\StepResource;
+use BlueFission\Wise\Res\TodoResource;
+use BlueFission\Wise\Res\VariableResource;
+use BlueFission\Wise\Sys\DirectoryManager;
+use BlueFission\Wise\Sys\StorageRoot;
+use BlueFission\Val;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+class ResourceStorageRootTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'wise-resource-storage-' . uniqid();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->root);
+    }
+
+    #[DataProvider('resourceClasses')]
+    public function testResourceConstructsWithInjectedStorageRoot(
+        string $resourceClass,
+        string $scope,
+        ?string $storagePropertyName
+    ): void
+    {
+        $resource = new $resourceClass(new StorageRoot($this->root));
+
+        $this->assertInstanceOf($resourceClass, $resource);
+        $this->assertTrue(DirectoryManager::pathExists(
+            $this->root . DIRECTORY_SEPARATOR . $scope
+        ));
+
+        if ($storagePropertyName) {
+            $storageProperty = new ReflectionProperty($resourceClass, $storagePropertyName);
+            $storage = $storageProperty->getValue($resource);
+            $sourceProperty = new ReflectionProperty($storage, '_source');
+            $source = $sourceProperty->getValue($storage);
+            if (Val::is($source)) {
+                $source->close();
+                $sourceProperty->setValue($storage, null);
+            }
+        }
+        unset($resource);
+        gc_collect_cycles();
+    }
+
+    public static function resourceClasses(): array
+    {
+        return [
+            'action' => [ActionResource::class, 'system', '_storage'],
+            'api' => [APIResource::class, 'system', '_storage'],
+            'file' => [FileResource::class, 'files', null],
+            'note' => [NoteResource::class, 'system', '_storage'],
+            'schedule' => [ScheduleResource::class, 'system', '_storage'],
+            'step' => [StepResource::class, 'system', '_storage'],
+            'todo' => [TodoResource::class, 'system', '_storage'],
+            'variable' => [VariableResource::class, 'system', '_storage'],
+        ];
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!DirectoryManager::pathExists($path)) {
+            return;
+        }
+
+        $items = scandir($path) ?: [];
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $target = $path . DIRECTORY_SEPARATOR . $item;
+            if (DirectoryManager::pathExists($target)) {
+                $this->removeDirectory($target);
+                continue;
+            }
+
+            unlink($target);
+        }
+
+        rmdir($path);
+    }
+}

--- a/tests/Sys/StorageRootTest.php
+++ b/tests/Sys/StorageRootTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace BlueFission\Tests\Sys;
+
+use BlueFission\Behavioral\Behaviors\Event;
+use BlueFission\Wise\Sys\DirectoryManager;
+use BlueFission\Wise\Sys\StorageRoot;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class StorageRootTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'wise-storage-' . uniqid();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->root);
+    }
+
+    public function testPreparesConfiguredStoragePath(): void
+    {
+        $storage = new StorageRoot($this->root);
+        $path = $storage->prepare('system');
+
+        $this->assertSame($this->root . DIRECTORY_SEPARATOR . 'system', $path);
+        $this->assertTrue(DirectoryManager::pathExists($path));
+    }
+
+    public function testDispatchesSuccessWhenPathIsPrepared(): void
+    {
+        $storage = new StorageRoot($this->root);
+        $dispatched = false;
+        $storage->when(Event::SUCCESS, function () use (&$dispatched): void {
+            $dispatched = true;
+        });
+
+        $storage->prepare('files');
+
+        $this->assertTrue($dispatched);
+    }
+
+    public function testRejectsTraversalInRootAndSegments(): void
+    {
+        $this->expectException(RuntimeException::class);
+        new StorageRoot($this->root . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'outside');
+    }
+
+    public function testRejectsNestedStorageSegment(): void
+    {
+        $storage = new StorageRoot($this->root);
+
+        $this->expectException(RuntimeException::class);
+        $storage->path('system/other');
+    }
+
+    public function testRejectsUnwritableStoragePath(): void
+    {
+        $storage = new class($this->root) extends StorageRoot {
+            protected function isWritable(string $path): bool
+            {
+                return false;
+            }
+        };
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Storage path is unavailable');
+        $storage->prepare('system');
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!DirectoryManager::pathExists($path)) {
+            return;
+        }
+
+        $items = scandir($path) ?: [];
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $target = $path . DIRECTORY_SEPARATOR . $item;
+            if (DirectoryManager::pathExists($target)) {
+                $this->removeDirectory($target);
+                continue;
+            }
+
+            unlink($target);
+        }
+
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
## Intent
Replace host-specific storage constants with a portable, injectable Wise storage contract.

## User stories / acceptance criteria
- Resource constructors work in a clean package bootstrap without host constants.
- Hosts can inject an explicit storage root or set WISE_STORAGE_ROOT.
- The legacy host constant remains a documented compatibility fallback.
- Paths are normalized, traversal is rejected, and unavailable roots fail deterministically.
- Persisted resource and browser download paths use the shared contract.

## Key files changed
- src/Wise/Sys/StorageRoot.php
- persisted resource constructors under src/Wise/Res
- src/Wise/Prg/WebBrowser.php
- STORAGE.md
- focused storage tests

## How to test
- vendor/bin/phpunit --do-not-cache-result
- php -l src/Wise/Sys/StorageRoot.php
- git diff --check

## QA checklist
- [x] Full suite: 179 tests, 416 assertions, 1 expected skip
- [x] Configured, unavailable, and traversal paths covered
- [x] Seven persisted resource types and file resource injection covered
- [x] No secrets or host-local paths added

## Approval conditions
- CI is green.
- Storage ownership and compatibility behavior match issue #22.
- Review confirms no resource-specific persistence behavior regressed.

Closes #22