### PR TITLE
Complete context-aware command suggestions

### DIFF
--- a/src/Wise/Cmd/CommandSuggester.php
+++ b/src/Wise/Cmd/CommandSuggester.php
@@ -34,6 +34,18 @@ class CommandSuggester
         $tokens = preg_split('/\s+/', $input);
         $lastToken = Str::make((string)($tokens[Arr::size($tokens) - 1] ?? ''))->lower()->val();
 
+        if (Arr::has($this->resources, $lastToken, true)) {
+            $verbs = Arr::make($this->verbsForResource($lastToken))->slice(0, 3);
+            if ($verbs->isNotEmpty()) {
+                $suggestions = $verbs
+                    ->map(fn($verb) => "{$verb} {$lastToken}")
+                    ->values()
+                    ->toArray();
+
+                return 'tab: ' . Arr::make($suggestions)->join(' | ')->val();
+            }
+        }
+
         if (Str::isEmpty((string)$command->verb) && !Str::isEmpty($lastToken)) {
             $verb = $this->bestMatch($lastToken, $this->verbs);
             if (Val::isNotEmpty($verb)) {
@@ -87,6 +99,13 @@ class CommandSuggester
         $command = $this->parser->parse($input);
         $tokens = preg_split('/\s+/', $input);
         $lastToken = Str::make((string)($tokens[Arr::size($tokens) - 1] ?? ''))->lower()->val();
+
+        if (Arr::has($this->resources, $lastToken, true)) {
+            $verbs = $this->verbsForResource($lastToken);
+            if (Arr::isNotEmpty($verbs)) {
+                return Str::make("{$verbs[0]} {$lastToken}")->trim()->val();
+            }
+        }
 
         if (Str::isEmpty((string)$command->verb) && !Str::isEmpty($lastToken)) {
             $verb = $this->bestMatch($lastToken, $this->verbs);

--- a/tests/Cli/ReplKeyInputTest.php
+++ b/tests/Cli/ReplKeyInputTest.php
@@ -9,6 +9,8 @@ use BlueFission\Wise\Sys\Drivers\IDisplayDriver;
 use BlueFission\Wise\Sys\KeyInputManager;
 use BlueFission\Wise\Sys\IO\IInputSource;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use ReflectionProperty;
 
 final class ReplKeyInputTest extends TestCase
 {
@@ -58,6 +60,24 @@ final class ReplKeyInputTest extends TestCase
         $console->listen();
 
         $this->assertNotSame('', $repl->hintValue());
+    }
+
+    public function testHintRenderingDoesNotMutatePromptOrCursor(): void
+    {
+        $input = new SequenceInputSource(['list']);
+        $console = $this->makeConsole($input);
+        $repl = new REPL();
+        $console->addComponent($repl);
+        $console->listen();
+
+        $cursorProperty = new ReflectionProperty($repl, '_cursor');
+        $cursor = $cursorProperty->getValue($repl);
+        $before = [$repl->inputValue(), $cursor->getX(), $cursor->getY()];
+
+        $updateHint = new ReflectionMethod($repl, 'updateHint');
+        $updateHint->invoke($repl, 'show');
+
+        $this->assertSame($before, [$repl->inputValue(), $cursor->getX(), $cursor->getY()]);
     }
 
     public function testTabCompletesPromptBuffer(): void

--- a/tests/Cmd/CommandSuggesterTest.php
+++ b/tests/Cmd/CommandSuggesterTest.php
@@ -40,6 +40,15 @@ final class CommandSuggesterTest extends TestCase
         $this->assertStringContainsString('list all resources', $hint);
     }
 
+    public function testSuggestsActionsForResourceOnlyInput(): void
+    {
+        $suggester = new CommandSuggester();
+        $hint = $suggester->hint('todo');
+
+        $this->assertStringContainsString('todo', $hint);
+        $this->assertMatchesRegularExpression('/tab: [a-z]+ todo/', $hint);
+    }
+
     public function testCompletesPartialVerb(): void
     {
         $suggester = new CommandSuggester();


### PR DESCRIPTION
## Intent
Complete the command suggestion contract by prioritizing exact resources over fuzzy verb matches and proving hint rendering is non-mutating.

## User stories / acceptance criteria
- Empty, partial verb, exact resource, and typo input return deterministic hints.
- Exact resources resolve to action suggestions before fuzzy verb matching.
- Hint rendering does not change the prompt buffer or cursor position.
- Tab completion remains deterministic.

## Key files changed
- src/Wise/Cmd/CommandSuggester.php
- tests/Cmd/CommandSuggesterTest.php
- tests/Cli/ReplKeyInputTest.php

## How to test
- vendor/bin/phpunit --do-not-cache-result tests/Cmd/CommandSuggesterTest.php tests/Cli/ReplKeyInputTest.php
- vendor/bin/phpunit --do-not-cache-result

## QA checklist
- [x] Focused: 13 tests, 18 assertions
- [x] Full: 168 tests, 396 assertions, 1 expected skip
- [x] PHP lint and diff check pass

## Approval conditions
- CI is green.
- Review confirms exact-resource precedence does not regress partial verb completion.

Closes #2