### PR TITLE
Add parse-only script validation

### DIFF
--- a/src/Wise/Arc/Kernel.php
+++ b/src/Wise/Arc/Kernel.php
@@ -19,6 +19,7 @@ use BlueFission\Collections\Collection;
 use BlueFission\Behavioral\Behaviors\Event;
 use BlueFission\IPC\IPC;
 use BlueFission\Str;
+use BlueFission\Val;
 use BlueFission\Wise\Usr\Profile;
 use BlueFission\Wise\Sys\Memory\WorkingMemoryCoordinator;
 use BlueFission\Wise\Exe\{BridgeRegistry, BridgeContext};
@@ -284,6 +285,23 @@ class Kernel {
         $this->_output = $output;
     }
 
+    public function validateScript(string $request): string
+    {
+        if (Val::isNull($this->_bridgeRegistry)) {
+            return 'No script bridges configured.';
+        }
+
+        $path = $this->resolveScriptPath($request, $this->scriptBasePath());
+        if (Val::isNull($path)) {
+            return 'Script not found or unsupported.';
+        }
+
+        $messages = [];
+        $context = $this->buildBridgeContext($messages);
+
+        return $this->_bridgeRegistry->validateFile($path, $context)->output();
+    }
+
     public function runAsync( $task ){
         // Call the do method statically
         return $this->_async::do($task);
@@ -481,6 +499,10 @@ class Kernel {
 
     private function resolveScriptPath(string $path, string $basePath): ?string
     {
+        $path = Str::make($path)
+            ->replace('/', DIRECTORY_SEPARATOR)
+            ->replace('\\', DIRECTORY_SEPARATOR)
+            ->val();
         $candidate = $path;
         if (!FileSystemManager::pathExists($candidate)) {
             $candidate = $basePath . DIRECTORY_SEPARATOR . $path;

--- a/src/Wise/Cmd/CommandHandler.php
+++ b/src/Wise/Cmd/CommandHandler.php
@@ -69,6 +69,7 @@ class CommandHandler {
         $this->registerAlias('clear', 'clearScreen');
         $this->registerAlias('exit', 'exit');
         $this->registerAlias('mem', 'memory');
+        $this->registerAlias('validate', 'validateScript');
         // Add more aliases as needed
     }
 
@@ -184,6 +185,15 @@ class CommandHandler {
 
     public function exit() {
         return 'Goodbye.';
+    }
+
+    public function validateScript($path = null): string
+    {
+        if (Val::isNull($path) || Str::isEmpty((string)$path)) {
+            return 'Usage: validate <script>';
+        }
+
+        return $this->_kernel->validateScript((string)$path);
     }
 
     // Add more internal commands as needed

--- a/src/Wise/Exe/BridgeRegistry.php
+++ b/src/Wise/Exe/BridgeRegistry.php
@@ -61,4 +61,31 @@ class BridgeRegistry extends Obj
 
         return $result;
     }
+
+    public function validateFile(string $path, BridgeContext $context): BridgeResult
+    {
+        $this->dispatch(Event::STARTED, new Meta(data: [
+            'path' => $path,
+            'mode' => 'validate',
+        ], src: $this));
+
+        $bridge = $this->bridgeForFile($path);
+        if (!$bridge instanceof IValidatingBridge) {
+            $this->dispatch(Event::FAILURE, new Meta(data: [
+                'path' => $path,
+                'mode' => 'validate',
+            ], src: $this));
+
+            return BridgeResult::failure('No validating bridge registered for file: ' . $path);
+        }
+
+        $result = $bridge->validateFile($path, $context);
+        $this->dispatch($result->successFlag() ? Event::COMPLETE : Event::FAILURE, new Meta(data: [
+            'path' => $path,
+            'bridge' => $bridge->name(),
+            'mode' => 'validate',
+        ], src: $this));
+
+        return $result;
+    }
 }

--- a/src/Wise/Exe/IValidatingBridge.php
+++ b/src/Wise/Exe/IValidatingBridge.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BlueFission\Wise\Exe;
+
+interface IValidatingBridge
+{
+    public function validateFile(string $path, BridgeContext $context): BridgeResult;
+}

--- a/src/Wise/Exe/JenssBridge.php
+++ b/src/Wise/Exe/JenssBridge.php
@@ -7,10 +7,11 @@ use BlueFission\Behavioral\Behaviors\Event;
 use BlueFission\Behavioral\Behaviors\Meta;
 use BlueFission\Obj;
 use BlueFission\Str;
+use BlueFission\Val;
 use BlueFission\Wise\Sys\DirectoryManager;
 use BlueFission\Wise\Sys\FileSystemManager;
 
-class JenssBridge extends Obj implements IBridge
+class JenssBridge extends Obj implements IBridge, IValidatingBridge
 {
     private const JENERATOR_PARSER = \BlueFission\Jenerator\Parsing\JenssParser::class;
     private const JENERATOR_INTERPRETER = \BlueFission\Jenerator\Runtime\Interpreter::class;
@@ -74,6 +75,53 @@ class JenssBridge extends Obj implements IBridge
             return BridgeResult::failure('JenSS execution failed: ' . $e->getMessage(), [
                 'path' => $path,
                 'exception' => $e::class,
+            ]);
+        }
+    }
+
+    public function validateFile(string $path, BridgeContext $context): BridgeResult
+    {
+        $this->dispatch(Event::STARTED, new Meta(data: [
+            'path' => $path,
+            'mode' => 'validate',
+        ], src: $this));
+
+        $classes = $this->resolveRuntimeClasses();
+        if (Val::isNull($classes)) {
+            $this->dispatch(Event::FAILURE, new Meta(data: [
+                'path' => $path,
+                'mode' => 'validate',
+            ], src: $this));
+
+            return BridgeResult::failure('JenSS interpreter is not available in this environment.');
+        }
+
+        $parserClass = $classes['parser'];
+
+        try {
+            $parser = new $parserClass();
+            $parser->parseFile($path);
+
+            $this->dispatch(Event::COMPLETE, new Meta(data: [
+                'path' => $path,
+                'mode' => 'validate',
+            ], src: $this));
+
+            return BridgeResult::success('Script is valid.', [
+                'path' => $path,
+                'mode' => 'validate',
+            ]);
+        } catch (\Throwable $exception) {
+            $this->dispatch(Event::FAILURE, new Meta(data: [
+                'path' => $path,
+                'mode' => 'validate',
+                'error' => $exception->getMessage(),
+            ], src: $this));
+
+            return BridgeResult::failure('JenSS validation failed: ' . $exception->getMessage(), [
+                'path' => $path,
+                'mode' => 'validate',
+                'exception' => $exception::class,
             ]);
         }
     }

--- a/tests/ExeBridgeTest.php
+++ b/tests/ExeBridgeTest.php
@@ -72,6 +72,34 @@ final class ExeBridgeTest extends TestCase
         $this->assertSame('bad-inline.jss', $result->meta()['path'] ?? null);
     }
 
+    public function testJenssBridgeValidatesFileWithoutExecutingIt(): void
+    {
+        if (!class_exists(\BlueFission\Jenerator\Parsing\JenssParser::class)) {
+            $this->markTestSkipped('JenSS parser not available.');
+        }
+
+        $path = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'examples'
+            . DIRECTORY_SEPARATOR . 'root' . DIRECTORY_SEPARATOR . 'cmd'
+            . DIRECTORY_SEPARATOR . 'hello.jss';
+
+        $result = (new JenssBridge())->validateFile($path, new BridgeContext());
+
+        $this->assertTrue($result->successFlag());
+        $this->assertSame('Script is valid.', $result->output());
+        $this->assertSame('validate', $result->meta()['mode'] ?? null);
+    }
+
+    public function testRegistryRejectsValidationForExecutionOnlyBridge(): void
+    {
+        $registry = new BridgeRegistry();
+        $registry->register(new VibeBridge());
+
+        $result = $registry->validateFile('template.vibe', new BridgeContext());
+
+        $this->assertFalse($result->successFlag());
+        $this->assertStringContainsString('No validating bridge registered', $result->output());
+    }
+
     public function testVibeBridgeReportsMissingDependency(): void
     {
         $bridge = new VibeBridge();

--- a/tests/IO/CommandPipelineTest.php
+++ b/tests/IO/CommandPipelineTest.php
@@ -9,6 +9,7 @@ use BlueFission\Wise\Exe\BridgeContext;
 use BlueFission\Wise\Exe\BridgeRegistry;
 use BlueFission\Wise\Exe\BridgeResult;
 use BlueFission\Wise\Exe\IBridge;
+use BlueFission\Wise\Exe\IValidatingBridge;
 use BlueFission\Wise\Sys\FileSystemManager;
 use BlueFission\Wise\Sys\DirectoryManager;
 use BlueFission\Wise\Sys\KeyInputManager;
@@ -103,6 +104,22 @@ final class CommandPipelineTest extends TestCase
         $this->assertFalse($kernel->isRunning());
     }
 
+    public function testValidateCommandParsesScriptWithoutExecutingIt(): void
+    {
+        $kernel = $this->makeKernel();
+        $bridge = new FakeBridge();
+        $registry = new BridgeRegistry();
+        $registry->register($bridge);
+        $kernel->setBridgeRegistry($registry);
+
+        $kernel->handle('validate cmd/hello.jss');
+
+        $this->assertSame('Script is valid.', $kernel->lastOutput());
+        $this->assertSame([], $bridge->paths());
+        $this->assertCount(1, $bridge->validatedPaths());
+        $this->assertStringEndsWith('cmd' . DIRECTORY_SEPARATOR . 'hello.jss', $bridge->validatedPaths()[0]);
+    }
+
     private function makeKernel(): TestKernel
     {
         $processManager = new ProcessManager();
@@ -173,9 +190,10 @@ final class TestKernel extends Kernel
     }
 }
 
-final class FakeBridge implements IBridge
+final class FakeBridge implements IBridge, IValidatingBridge
 {
     private array $paths = [];
+    private array $validatedPaths = [];
 
     public function name(): string
     {
@@ -204,12 +222,30 @@ final class FakeBridge implements IBridge
         return BridgeResult::success('ran:' . $label);
     }
 
+    public function validateFile(string $path, BridgeContext $context): BridgeResult
+    {
+        $this->validatedPaths[] = $path;
+
+        return BridgeResult::success('Script is valid.', [
+            'path' => $path,
+            'mode' => 'validate',
+        ]);
+    }
+
     /**
      * @return array<int, string>
      */
     public function paths(): array
     {
         return $this->paths;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function validatedPaths(): array
+    {
+        return $this->validatedPaths;
     }
 }
 


### PR DESCRIPTION
## Intent
Add the first-class parse-only lifecycle for authored scripts without executing runtime actions.

## User stories / acceptance criteria
- validate <script> resolves explicit and discovered script paths through the existing shell boundary.
- Validation requires an explicitly validating bridge.
- JenSS validation parses the file without constructing or running the interpreter.
- Unsupported bridges and unavailable scripts return deterministic failures.
- Script paths are normalized across Windows, WSL, and Linux.

## Key files changed
- src/Wise/Exe/IValidatingBridge.php
- src/Wise/Exe/BridgeRegistry.php
- src/Wise/Exe/JenssBridge.php
- src/Wise/Cmd/CommandHandler.php
- src/Wise/Arc/Kernel.php
- bridge and pipeline tests

## How to test
- vendor/bin/phpunit --do-not-cache-result tests/ExeBridgeTest.php tests/IO/CommandPipelineTest.php
- vendor/bin/phpunit --do-not-cache-result

## QA checklist
- [x] Focused: 10 tests, 26 assertions
- [x] Full: 169 tests, 402 assertions, 1 expected skip
- [x] PHP lint and diff check pass

## Approval conditions
- CI is green.
- Review confirms validation cannot execute interpreter runtime behavior.
- Remaining argument, capability, timeout, and cancellation work stays tracked in #21.

Refs #21