### PR TITLE
Add structured script execution contract

### DIFF
--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -1,0 +1,15 @@
+# Script Execution
+
+Wise discovers registered script extensions through `BridgeRegistry`. A script can still be invoked by its path or discovered command name with the bridge's basic `runFile` contract.
+
+Use the explicit execution command when a script needs structured inputs:
+
+```text
+run <script> [--arg=value] [--cwd=path] [--stdin=value] [--env=KEY=VALUE] [--cap=name] [--timeout=ms]
+```
+
+Capabilities are denied by default. Supported capability names are `environment`, `filesystem`, `network`, `process`, and `provider`. Environment values must be supplied explicitly with `--env` and are projected only when the `environment` capability is granted. Working and include paths are projected only when `filesystem` is granted.
+
+`ExecutionRequest` is the stable extension contract for arguments, working directory, standard input, allowlisted environment, capabilities, timeout, and cooperative cancellation. An executing bridge implements `IExecutingBridge`; bridges that only implement `IBridge` remain available through normal implicit script invocation.
+
+JenSS execution checks cancellation and timeout before and after interpreter execution. Runtime integrations that support finer-grained cooperative checkpoints can use the request metadata carried in `BridgeContext::vars()` without changing command syntax.

--- a/src/Wise/Arc/Kernel.php
+++ b/src/Wise/Arc/Kernel.php
@@ -18,11 +18,12 @@ use BlueFission\Services\Authenticator as Auth;
 use BlueFission\Collections\Collection;
 use BlueFission\Behavioral\Behaviors\Event;
 use BlueFission\IPC\IPC;
+use BlueFission\Arr;
 use BlueFission\Str;
 use BlueFission\Val;
 use BlueFission\Wise\Usr\Profile;
 use BlueFission\Wise\Sys\Memory\WorkingMemoryCoordinator;
-use BlueFission\Wise\Exe\{BridgeRegistry, BridgeContext};
+use BlueFission\Wise\Exe\{BridgeRegistry, BridgeContext, BridgeResult, ExecutionRequest};
 use BlueFission\Wise\Res\ScriptedResourceRegistry;
 
 class Kernel {
@@ -277,12 +278,29 @@ class Kernel {
         $result = $this->_bridgeRegistry->runFile($path, $context);
 
         $output = $result->output();
-        if ($output === '' && $messages !== []) {
-            $output = implode(PHP_EOL, $messages);
+        if (Str::isEmpty($output) && Val::isNotEmpty($messages)) {
+            $output = Arr::make($messages)->join(PHP_EOL)->val();
         }
 
         $this->recordMemoryOutput((string)$output);
         $this->_output = $output;
+    }
+
+    public function executeScript(ExecutionRequest $request): BridgeResult
+    {
+        if (Val::isNull($this->_bridgeRegistry)) {
+            return BridgeResult::failure('No script bridges configured.');
+        }
+
+        $path = $this->resolveScriptPath($request->path(), $this->scriptBasePath());
+        if (Val::isNull($path)) {
+            return BridgeResult::failure('Script not found or unsupported.');
+        }
+
+        $messages = [];
+        $context = $this->buildBridgeContext($messages);
+
+        return $this->_bridgeRegistry->execute($request->withPath($path), $context);
     }
 
     public function validateScript(string $request): string

--- a/src/Wise/Cmd/CommandHandler.php
+++ b/src/Wise/Cmd/CommandHandler.php
@@ -8,6 +8,7 @@ use BlueFission\Val;
 use BlueFission\Wise\Arc\Kernel;
 use BlueFission\Data\FileSystem;
 use BlueFission\Wise\Res\ResourceHelper;
+use BlueFission\Wise\Exe\ExecutionRequest;
 use BlueFission\Behavioral\Behaviors\Behavior;
 
 class CommandHandler {
@@ -70,6 +71,7 @@ class CommandHandler {
         $this->registerAlias('exit', 'exit');
         $this->registerAlias('mem', 'memory');
         $this->registerAlias('validate', 'validateScript');
+        $this->registerAlias('run', 'runScript');
         // Add more aliases as needed
     }
 
@@ -194,6 +196,58 @@ class CommandHandler {
         }
 
         return $this->_kernel->validateScript((string)$path);
+    }
+
+    public function runScript($path = null, ...$options): string
+    {
+        if (Val::isNull($path) || Str::isEmpty((string)$path)) {
+            return 'Usage: run <script> [--arg=value] [--cwd=path] [--stdin=value] [--env=KEY=VALUE] [--cap=name] [--timeout=ms]';
+        }
+
+        $arguments = [];
+        $environment = [];
+        $capabilities = [];
+        $workingDirectory = null;
+        $standardInput = '';
+        $timeoutMs = 0;
+
+        foreach ($options as $option) {
+            $option = (string)$option;
+            if (Str::startsWith($option, '--arg=')) {
+                $arguments[] = Str::sub($option, 6);
+            } elseif (Str::startsWith($option, '--cwd=')) {
+                $workingDirectory = Str::sub($option, 6);
+            } elseif (Str::startsWith($option, '--stdin=')) {
+                $standardInput = Str::sub($option, 8);
+            } elseif (Str::startsWith($option, '--env=')) {
+                $pair = Str::make(Str::sub($option, 6))->splitBy('/=/', 2)->toArray();
+                if (Arr::size($pair) === 2 && Str::isNotEmpty((string)$pair[0])) {
+                    $environment[(string)$pair[0]] = (string)$pair[1];
+                }
+            } elseif (Str::startsWith($option, '--cap=')) {
+                $capabilities = Arr::merge(
+                    $capabilities,
+                    Str::make(Str::sub($option, 6))->split(',')->toArray()
+                );
+            } elseif (Str::startsWith($option, '--timeout=')) {
+                $timeout = Str::sub($option, 10);
+                $timeoutMs = is_numeric($timeout) ? (int)$timeout : 0;
+            } else {
+                $arguments[] = $option;
+            }
+        }
+
+        $result = $this->_kernel->executeScript(new ExecutionRequest(
+            (string)$path,
+            $arguments,
+            $workingDirectory,
+            $standardInput,
+            $environment,
+            $capabilities,
+            $timeoutMs
+        ));
+
+        return $result->output();
     }
 
     // Add more internal commands as needed

--- a/src/Wise/Exe/BridgeContext.php
+++ b/src/Wise/Exe/BridgeContext.php
@@ -133,4 +133,25 @@ class BridgeContext extends Obj
     {
         return $this->llm;
     }
+
+    public function scoped(
+        array $env = [],
+        array $basePaths = [],
+        array $vars = [],
+        array $includePaths = []
+    ): self
+    {
+        return new self(
+            $this->kernel,
+            $this->console,
+            $env,
+            $basePaths,
+            $includePaths,
+            $vars,
+            $this->outputHandler,
+            $this->promptHandler,
+            $this->resourceResolver,
+            $this->llm
+        );
+    }
 }

--- a/src/Wise/Exe/BridgeRegistry.php
+++ b/src/Wise/Exe/BridgeRegistry.php
@@ -62,6 +62,18 @@ class BridgeRegistry extends Obj
         return $result;
     }
 
+    public function execute(ExecutionRequest $request, BridgeContext $context): BridgeResult
+    {
+        $bridge = $this->bridgeForFile($request->path());
+        if (!$bridge instanceof IExecutingBridge) {
+            return BridgeResult::failure('No executing bridge registered for file: ' . $request->path(), [
+                'execution' => $request->metadata(),
+            ]);
+        }
+
+        return $bridge->execute($request, $context);
+    }
+
     public function validateFile(string $path, BridgeContext $context): BridgeResult
     {
         $this->dispatch(Event::STARTED, new Meta(data: [

--- a/src/Wise/Exe/ExecutionRequest.php
+++ b/src/Wise/Exe/ExecutionRequest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace BlueFission\Wise\Exe;
+
+use BlueFission\Arr;
+use BlueFission\Func;
+use BlueFission\Num;
+use BlueFission\Obj;
+use BlueFission\Str;
+use BlueFission\Val;
+
+class ExecutionRequest extends Obj
+{
+    public const CAP_ENVIRONMENT = 'environment';
+    public const CAP_FILESYSTEM = 'filesystem';
+    public const CAP_NETWORK = 'network';
+    public const CAP_PROCESS = 'process';
+    public const CAP_PROVIDER = 'provider';
+
+    private Str $path;
+    private Arr $arguments;
+    private ?Str $workingDirectory;
+    private Str $standardInput;
+    private Arr $environment;
+    private Arr $capabilities;
+    private Num $timeoutMs;
+    private $cancelCheck;
+    private float $startedAt;
+
+    public function __construct(
+        string $path,
+        array $arguments = [],
+        ?string $workingDirectory = null,
+        string $standardInput = '',
+        array $environment = [],
+        array $capabilities = [],
+        int $timeoutMs = 0,
+        ?callable $cancelCheck = null
+    ) {
+        parent::__construct();
+        $this->path = Str::make($path)->trim();
+        $this->arguments = Arr::make($arguments);
+        $this->workingDirectory = Val::isNotEmpty($workingDirectory)
+            ? Str::make((string)$workingDirectory)->trim()
+            : null;
+        $this->standardInput = Str::make($standardInput);
+        $this->environment = Arr::make($environment);
+        $this->capabilities = Arr::make($capabilities)
+            ->map(fn($capability) => Str::make((string)$capability)->trim()->lower()->val())
+            ->unique();
+        $this->timeoutMs = Num::make(Num::max(0, $timeoutMs));
+        $this->cancelCheck = $cancelCheck;
+        $this->startedAt = microtime(true);
+    }
+
+    public function path(): string
+    {
+        return $this->path->val();
+    }
+
+    public function withPath(string $path): self
+    {
+        $copy = clone $this;
+        $copy->path = Str::make($path)->trim();
+        return $copy;
+    }
+
+    public function arguments(): array
+    {
+        return $this->arguments->toArray();
+    }
+
+    public function workingDirectory(): ?string
+    {
+        return $this->workingDirectory?->val();
+    }
+
+    public function standardInput(): string
+    {
+        return $this->standardInput->val();
+    }
+
+    public function environment(): array
+    {
+        return $this->environment->toArray();
+    }
+
+    public function capabilities(): array
+    {
+        return $this->capabilities->toArray();
+    }
+
+    public function timeoutMs(): int
+    {
+        return (int)$this->timeoutMs->val();
+    }
+
+    public function hasCapability(string $capability): bool
+    {
+        return $this->capabilities->has(Str::lower($capability), true);
+    }
+
+    public function isCancelled(): bool
+    {
+        return Func::isCallable($this->cancelCheck) && (bool)($this->cancelCheck)();
+    }
+
+    public function hasTimedOut(): bool
+    {
+        return $this->timeoutMs() > 0
+            && ((microtime(true) - $this->startedAt) * 1000) >= $this->timeoutMs();
+    }
+
+    public function scopedContext(BridgeContext $context): BridgeContext
+    {
+        $basePaths = [];
+        if ($this->hasCapability(self::CAP_FILESYSTEM)) {
+            $basePaths = $context->basePaths();
+            if (Val::isNotEmpty($this->workingDirectory())) {
+                $basePaths = Arr::merge($basePaths, [$this->workingDirectory()]);
+            }
+        }
+
+        $environment = $this->hasCapability(self::CAP_ENVIRONMENT)
+            ? $this->environment()
+            : [];
+
+        return $context->scoped(
+            $environment,
+            Arr::make($basePaths)->unique()->toArray(),
+            Arr::merge($context->vars(), [
+                'execution' => $this->metadata(),
+                'args' => $this->arguments(),
+                'stdin' => $this->standardInput(),
+            ]),
+            $this->hasCapability(self::CAP_FILESYSTEM) ? $context->includePaths() : []
+        );
+    }
+
+    public function metadata(): array
+    {
+        return [
+            'path' => $this->path(),
+            'args' => $this->arguments(),
+            'cwd' => $this->hasCapability(self::CAP_FILESYSTEM) ? $this->workingDirectory() : null,
+            'env_keys' => $this->hasCapability(self::CAP_ENVIRONMENT)
+                ? $this->environment->keys()->toArray()
+                : [],
+            'capabilities' => $this->capabilities(),
+            'timeout_ms' => $this->timeoutMs(),
+        ];
+    }
+}

--- a/src/Wise/Exe/IExecutingBridge.php
+++ b/src/Wise/Exe/IExecutingBridge.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BlueFission\Wise\Exe;
+
+interface IExecutingBridge
+{
+    public function execute(ExecutionRequest $request, BridgeContext $context): BridgeResult;
+}

--- a/src/Wise/Exe/JenssBridge.php
+++ b/src/Wise/Exe/JenssBridge.php
@@ -11,7 +11,7 @@ use BlueFission\Val;
 use BlueFission\Wise\Sys\DirectoryManager;
 use BlueFission\Wise\Sys\FileSystemManager;
 
-class JenssBridge extends Obj implements IBridge, IValidatingBridge
+class JenssBridge extends Obj implements IBridge, IValidatingBridge, IExecutingBridge
 {
     private const JENERATOR_PARSER = \BlueFission\Jenerator\Parsing\JenssParser::class;
     private const JENERATOR_INTERPRETER = \BlueFission\Jenerator\Runtime\Interpreter::class;
@@ -77,6 +77,36 @@ class JenssBridge extends Obj implements IBridge, IValidatingBridge
                 'exception' => $e::class,
             ]);
         }
+    }
+
+    public function execute(ExecutionRequest $request, BridgeContext $context): BridgeResult
+    {
+        if ($request->isCancelled()) {
+            return BridgeResult::failure('JenSS execution cancelled.', [
+                'execution' => $request->metadata(),
+                'cancelled' => true,
+            ]);
+        }
+
+        if ($request->hasTimedOut()) {
+            return BridgeResult::failure('JenSS execution timed out.', [
+                'execution' => $request->metadata(),
+                'timed_out' => true,
+            ]);
+        }
+
+        $result = $this->runFile($request->path(), $request->scopedContext($context));
+        $meta = Arr::merge($result->meta(), ['execution' => $request->metadata()]);
+
+        if ($request->isCancelled()) {
+            return BridgeResult::failure('JenSS execution cancelled.', Arr::merge($meta, ['cancelled' => true]));
+        }
+
+        if ($request->hasTimedOut()) {
+            return BridgeResult::failure('JenSS execution timed out.', Arr::merge($meta, ['timed_out' => true]));
+        }
+
+        return new BridgeResult($result->successFlag(), $result->output(), $meta);
     }
 
     public function validateFile(string $path, BridgeContext $context): BridgeResult

--- a/tests/CommandHandlerTest.php
+++ b/tests/CommandHandlerTest.php
@@ -5,6 +5,8 @@ namespace BlueFission\Tests;
 use BlueFission\Wise\Cmd\CommandHandler;
 use BlueFission\Wise\Arc\Kernel;
 use BlueFission\Wise\Usr\Profile;
+use BlueFission\Wise\Exe\BridgeResult;
+use BlueFission\Wise\Exe\ExecutionRequest;
 use PHPUnit\Framework\TestCase;
 
 final class CommandHandlerTest extends TestCase
@@ -97,6 +99,23 @@ final class CommandHandlerTest extends TestCase
         $this->assertSame('Insufficient permissions to modify global memory.', $result);
         $this->assertNull($kernel->memoryMax['global']);
     }
+
+    public function testRunCommandBuildsStructuredExecutionRequest(): void
+    {
+        $kernel = new FakeKernel();
+        $handler = new CommandHandler($kernel);
+
+        $result = $handler->handle(
+            'run demo.jss --arg=one --env=SAFE=yes --cap=environment --timeout=25'
+        );
+
+        $this->assertSame('executed', $result);
+        $this->assertSame('demo.jss', $kernel->executionRequest?->path());
+        $this->assertSame(['one'], $kernel->executionRequest?->arguments());
+        $this->assertSame(['SAFE' => 'yes'], $kernel->executionRequest?->environment());
+        $this->assertSame([ExecutionRequest::CAP_ENVIRONMENT], $kernel->executionRequest?->capabilities());
+        $this->assertSame(25, $kernel->executionRequest?->timeoutMs());
+    }
 }
 
 final class FakeKernel extends Kernel
@@ -104,6 +123,7 @@ final class FakeKernel extends Kernel
     public array $lastCall = [];
     public array $memoryMax = ['user' => null, 'global' => null];
     public bool $workingMemoryEnabled = true;
+    public ?ExecutionRequest $executionRequest = null;
     private Profile $profile;
 
     public function __construct()
@@ -189,5 +209,11 @@ final class FakeKernel extends Kernel
     public function setProfile(Profile $profile): void
     {
         $this->profile = $profile;
+    }
+
+    public function executeScript(ExecutionRequest $request): BridgeResult
+    {
+        $this->executionRequest = $request;
+        return BridgeResult::success('executed');
     }
 }

--- a/tests/ExeBridgeTest.php
+++ b/tests/ExeBridgeTest.php
@@ -6,6 +6,7 @@ use BlueFission\Wise\Exe\BridgeContext;
 use BlueFission\Wise\Exe\BridgeRegistry;
 use BlueFission\Wise\Exe\JenssBridge;
 use BlueFission\Wise\Exe\VibeBridge;
+use BlueFission\Wise\Exe\ExecutionRequest;
 use PHPUnit\Framework\TestCase;
 
 final class ExeBridgeTest extends TestCase
@@ -87,6 +88,33 @@ final class ExeBridgeTest extends TestCase
         $this->assertTrue($result->successFlag());
         $this->assertSame('Script is valid.', $result->output());
         $this->assertSame('validate', $result->meta()['mode'] ?? null);
+    }
+
+    public function testJenssBridgeExecutesStructuredRequest(): void
+    {
+        if (!class_exists(\BlueFission\Jenerator\Runtime\Interpreter::class)) {
+            $this->markTestSkipped('JenSS interpreter not available.');
+        }
+
+        $path = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'examples'
+            . DIRECTORY_SEPARATOR . 'root' . DIRECTORY_SEPARATOR . 'cmd'
+            . DIRECTORY_SEPARATOR . 'hello.jss';
+        $request = new ExecutionRequest(
+            $path,
+            ['one'],
+            dirname($path),
+            'input',
+            ['SAFE' => 'yes'],
+            [ExecutionRequest::CAP_FILESYSTEM, ExecutionRequest::CAP_ENVIRONMENT],
+            5000
+        );
+
+        $result = (new JenssBridge())->execute($request, new BridgeContext());
+
+        $this->assertTrue($result->successFlag());
+        $this->assertStringContainsString('Hello from Wise.', $result->output());
+        $this->assertSame(['one'], $result->meta()['execution']['args']);
+        $this->assertSame(['SAFE'], $result->meta()['execution']['env_keys']);
     }
 
     public function testRegistryRejectsValidationForExecutionOnlyBridge(): void

--- a/tests/ExeExecutionRequestTest.php
+++ b/tests/ExeExecutionRequestTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace BlueFission\Tests;
+
+use BlueFission\Wise\Exe\BridgeContext;
+use BlueFission\Wise\Exe\BridgeRegistry;
+use BlueFission\Wise\Exe\ExecutionRequest;
+use BlueFission\Wise\Exe\JenssBridge;
+use BlueFission\Wise\Exe\VibeBridge;
+use PHPUnit\Framework\TestCase;
+
+final class ExeExecutionRequestTest extends TestCase
+{
+    public function testCapabilitiesProjectOnlyExplicitExecutionContext(): void
+    {
+        $context = new BridgeContext(
+            env: ['HOST_SECRET' => 'hidden'],
+            basePaths: ['base'],
+            includePaths: ['include'],
+            vars: ['existing' => true]
+        );
+        $request = new ExecutionRequest(
+            'task.jss',
+            ['one'],
+            'work',
+            'input',
+            ['SAFE' => 'yes'],
+            [ExecutionRequest::CAP_ENVIRONMENT, ExecutionRequest::CAP_FILESYSTEM]
+        );
+
+        $scoped = $request->scopedContext($context);
+
+        $this->assertSame(['SAFE' => 'yes'], $scoped->env());
+        $this->assertSame(['base', 'work'], $scoped->basePaths());
+        $this->assertSame(['include'], $scoped->includePaths());
+        $this->assertSame(['one'], $scoped->vars()['args']);
+        $this->assertSame('input', $scoped->vars()['stdin']);
+        $this->assertSame(['SAFE'], $scoped->vars()['execution']['env_keys']);
+    }
+
+    public function testMissingCapabilitiesRemoveHostAccessContext(): void
+    {
+        $context = new BridgeContext(
+            env: ['HOST_SECRET' => 'hidden'],
+            basePaths: ['base'],
+            includePaths: ['include']
+        );
+        $request = new ExecutionRequest('task.jss', environment: ['SAFE' => 'yes']);
+
+        $scoped = $request->scopedContext($context);
+
+        $this->assertSame([], $scoped->env());
+        $this->assertSame([], $scoped->basePaths());
+        $this->assertSame([], $scoped->includePaths());
+        $this->assertSame([], $request->metadata()['env_keys']);
+    }
+
+    public function testCancellationStopsJenssBeforeRuntimeExecution(): void
+    {
+        $request = new ExecutionRequest('task.jss', cancelCheck: static fn(): bool => true);
+
+        $result = (new JenssBridge())->execute($request, new BridgeContext());
+
+        $this->assertFalse($result->successFlag());
+        $this->assertSame('JenSS execution cancelled.', $result->output());
+        $this->assertTrue($result->meta()['cancelled']);
+    }
+
+    public function testRegistryRejectsBridgeWithoutExecutionContract(): void
+    {
+        $registry = new BridgeRegistry();
+        $registry->register(new VibeBridge());
+
+        $result = $registry->execute(new ExecutionRequest('template.vibe'), new BridgeContext());
+
+        $this->assertFalse($result->successFlag());
+        $this->assertStringContainsString('No executing bridge registered', $result->output());
+    }
+}


### PR DESCRIPTION
## Intent

Complete the executable configuration-script contract for explicit, capability-aware Wise programs.

## User Stories / Acceptance Criteria

- `run <script>` creates a typed execution request with args, cwd, stdin, allowlisted env, capabilities, and timeout.
- Environment and filesystem context are denied unless explicitly granted.
- Executing bridges return normal `BridgeResult` values for success, unsupported runtime, cancellation, timeout, syntax, and runtime failures.
- Existing implicit bridge execution remains backward compatible.
- JenSS executes a real side-effect-free script through the structured request.

## Key Files

- `src/Wise/Exe/ExecutionRequest.php`
- `src/Wise/Exe/IExecutingBridge.php`
- `src/Wise/Exe/JenssBridge.php`
- `src/Wise/Exe/BridgeRegistry.php`
- `src/Wise/Exe/BridgeContext.php`
- `src/Wise/Arc/Kernel.php`
- `src/Wise/Cmd/CommandHandler.php`
- `SCRIPTING.md`

## How To Test

```shell
vendor/bin/phpunit --do-not-cache-result tests/ExeExecutionRequestTest.php tests/ExeBridgeTest.php tests/CommandHandlerTest.php tests/IO/JenssBridgePipelineTest.php tests/IO/CommandPipelineTest.php
vendor/bin/phpunit --do-not-cache-result
git diff --check origin/main...HEAD
```

## QA Checklist

- [x] Real JenSS structured execution succeeds.
- [x] Cancellation and unsupported execution paths are deterministic.
- [x] Capability projection excludes host env and paths by default.
- [x] Focused suite: 25 tests, 65 assertions.
- [x] Full suite: 190 tests, 453 assertions, one expected skip.
- [x] Command and extension contracts documented.

## Approval Conditions

- CI remains green on supported PHP versions.
- Review confirms the capability defaults and backward-compatible bridge boundary.

Closes #21.
