### PR TITLE
Add optional authentication provider

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -1,0 +1,9 @@
+# Authentication Providers
+
+Wise authentication is exposed through `AuthProviderInterface`. The default CLI authenticator remains active when no advanced provider is installed or configured.
+
+`PresenceAuthProvider` maps a configured Presence authenticator registry into Wise `Profile` identity, role, and permission data. It does not create authenticators or read credentials from the environment. Applications inject the configured registry and may inject credential/context factories for custom credential types.
+
+Presence is optional until a tagged package is available through Packagist. Wise does not add a VCS-only dependency. When the package is absent, `NullAuthProvider` and the existing authenticator provide deterministic clean-install behavior.
+
+Secrets remain confined to `AuthRequest` and are not copied into outcomes, profiles, diagnostics, or metadata. Session and tenant identifiers may be supplied through the request context by the owning application.

--- a/src/Wise/Usr/Auth/AuthOutcome.php
+++ b/src/Wise/Usr/Auth/AuthOutcome.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace BlueFission\Wise\Usr\Auth;
+
+use BlueFission\Arr;
+use BlueFission\Obj;
+use BlueFission\Str;
+use BlueFission\Wise\Usr\Profile;
+
+class AuthOutcome extends Obj
+{
+    private bool $authenticated;
+    private ?Profile $profile;
+    private Str $reason;
+    private Arr $metadata;
+
+    public function __construct(
+        bool $authenticated,
+        ?Profile $profile = null,
+        string $reason = '',
+        array $metadata = []
+    ) {
+        parent::__construct();
+        $this->authenticated = $authenticated;
+        $this->profile = $profile;
+        $this->reason = Str::make($reason);
+        $this->metadata = Arr::make($metadata);
+    }
+
+    public static function success(Profile $profile, array $metadata = []): self
+    {
+        return new self(true, $profile, 'authenticated', $metadata);
+    }
+
+    public static function failure(string $reason, array $metadata = []): self
+    {
+        return new self(false, null, $reason, $metadata);
+    }
+
+    public function authenticated(): bool
+    {
+        return $this->authenticated;
+    }
+
+    public function profile(): ?Profile
+    {
+        return $this->profile;
+    }
+
+    public function reason(): string
+    {
+        return $this->reason->val();
+    }
+
+    public function metadata(): array
+    {
+        return $this->metadata->toArray();
+    }
+}

--- a/src/Wise/Usr/Auth/AuthProviderInterface.php
+++ b/src/Wise/Usr/Auth/AuthProviderInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace BlueFission\Wise\Usr\Auth;
+
+use BlueFission\Wise\Usr\Profile;
+
+interface AuthProviderInterface
+{
+    public function available(): bool;
+
+    public function authenticate(AuthRequest $request): AuthOutcome;
+
+    public function logout(): void;
+
+    public function isAuthenticated(): bool;
+
+    public function profile(): ?Profile;
+
+    public function hasPermission(string $permission): bool;
+}

--- a/src/Wise/Usr/Auth/AuthRequest.php
+++ b/src/Wise/Usr/Auth/AuthRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace BlueFission\Wise\Usr\Auth;
+
+use BlueFission\Arr;
+use BlueFission\Obj;
+use BlueFission\Str;
+
+class AuthRequest extends Obj
+{
+    private Str $type;
+    private Str $identifier;
+    private Str $secret;
+    private Arr $context;
+
+    public function __construct(string $identifier, string $secret, string $type = 'password', array $context = [])
+    {
+        parent::__construct();
+        $this->type = Str::make($type)->trim()->lower();
+        $this->identifier = Str::make($identifier)->trim();
+        $this->secret = Str::make($secret);
+        $this->context = Arr::make($context);
+    }
+
+    public function type(): string
+    {
+        return $this->type->val();
+    }
+
+    public function identifier(): string
+    {
+        return $this->identifier->val();
+    }
+
+    public function secret(): string
+    {
+        return $this->secret->val();
+    }
+
+    public function context(): array
+    {
+        return $this->context->toArray();
+    }
+}

--- a/src/Wise/Usr/Auth/NullAuthProvider.php
+++ b/src/Wise/Usr/Auth/NullAuthProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace BlueFission\Wise\Usr\Auth;
+
+use BlueFission\Obj;
+use BlueFission\Wise\Usr\Profile;
+
+class NullAuthProvider extends Obj implements AuthProviderInterface
+{
+    public function available(): bool
+    {
+        return false;
+    }
+
+    public function authenticate(AuthRequest $request): AuthOutcome
+    {
+        return AuthOutcome::failure('authentication_provider_unavailable');
+    }
+
+    public function logout(): void
+    {
+    }
+
+    public function isAuthenticated(): bool
+    {
+        return false;
+    }
+
+    public function profile(): ?Profile
+    {
+        return null;
+    }
+
+    public function hasPermission(string $permission): bool
+    {
+        return false;
+    }
+}

--- a/src/Wise/Usr/Auth/PresenceAuthProvider.php
+++ b/src/Wise/Usr/Auth/PresenceAuthProvider.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace BlueFission\Wise\Usr\Auth;
+
+use BlueFission\Arr;
+use BlueFission\Func;
+use BlueFission\Obj;
+use BlueFission\Str;
+use BlueFission\Val;
+use BlueFission\Wise\Usr\Profile;
+
+class PresenceAuthProvider extends Obj implements AuthProviderInterface
+{
+    private const REGISTRY = 'BlueFission\\Presence\\Auth\\AuthenticatorRegistry';
+    private const CREDENTIAL = 'BlueFission\\Presence\\Auth\\Credential';
+    private const CONTEXT = 'BlueFission\\Presence\\Support\\Context';
+
+    private ?object $registry;
+    private $credentialFactory;
+    private $contextFactory;
+    private ?AuthOutcome $outcome = null;
+
+    public function __construct(
+        ?object $registry = null,
+        ?callable $credentialFactory = null,
+        ?callable $contextFactory = null
+    ) {
+        parent::__construct();
+        $this->registry = $registry ?? $this->defaultRegistry();
+        $this->credentialFactory = $credentialFactory ?? $this->defaultCredentialFactory();
+        $this->contextFactory = $contextFactory ?? $this->defaultContextFactory();
+    }
+
+    public function available(): bool
+    {
+        return Val::is($this->registry)
+            && method_exists($this->registry, 'authenticate')
+            && Func::isCallable($this->credentialFactory)
+            && Func::isCallable($this->contextFactory);
+    }
+
+    public function authenticate(AuthRequest $request): AuthOutcome
+    {
+        if (!$this->available()) {
+            return $this->outcome = AuthOutcome::failure('presence_unavailable');
+        }
+
+        try {
+            $credential = ($this->credentialFactory)($request);
+            $context = ($this->contextFactory)($request);
+            $result = $this->registry->authenticate($credential, $context);
+        } catch (\Throwable $exception) {
+            return $this->outcome = AuthOutcome::failure('presence_authentication_failed', [
+                'exception' => $exception::class,
+            ]);
+        }
+
+        if (!is_object($result) || !method_exists($result, 'isSuccessful') || !$result->isSuccessful()) {
+            return $this->outcome = AuthOutcome::failure(
+                (string)($result->reason ?? 'authentication_failed'),
+                Arr::is($result->metadata ?? null) ? $result->metadata : []
+            );
+        }
+
+        $principal = $result->principal ?? null;
+        if (!is_object($principal) || !method_exists($principal, 'id')) {
+            return $this->outcome = AuthOutcome::failure('presence_principal_missing');
+        }
+
+        $profile = new Profile(
+            (string)$principal->id(),
+            $this->namesFromCollection(method_exists($principal, 'roles') ? $principal->roles() : null, ['user']),
+            $this->namesFromCollection(method_exists($principal, 'permissions') ? $principal->permissions() : null)
+        );
+
+        return $this->outcome = AuthOutcome::success($profile, Arr::merge(
+            Arr::is($result->metadata ?? null) ? $result->metadata : [],
+            ['provider' => 'presence']
+        ));
+    }
+
+    public function logout(): void
+    {
+        $this->outcome = null;
+    }
+
+    public function isAuthenticated(): bool
+    {
+        return Val::is($this->outcome) && $this->outcome->authenticated();
+    }
+
+    public function profile(): ?Profile
+    {
+        return $this->outcome?->profile();
+    }
+
+    public function hasPermission(string $permission): bool
+    {
+        return $this->profile()?->hasPermission($permission) ?? false;
+    }
+
+    private function defaultRegistry(): ?object
+    {
+        if (!class_exists(self::REGISTRY)) {
+            return null;
+        }
+
+        $class = self::REGISTRY;
+        return new $class();
+    }
+
+    private function defaultCredentialFactory(): ?callable
+    {
+        if (!class_exists(self::CREDENTIAL)) {
+            return null;
+        }
+
+        return static function (AuthRequest $request): object {
+            $class = self::CREDENTIAL;
+            $credential = new $class();
+            $credential->field('type', $request->type());
+            $credential->field('identifier', $request->identifier());
+            $credential->field('secret', $request->secret());
+            $credential->field('metadata', $request->context());
+            return $credential;
+        };
+    }
+
+    private function defaultContextFactory(): ?callable
+    {
+        if (!class_exists(self::CONTEXT)) {
+            return null;
+        }
+
+        return static function (AuthRequest $request): object {
+            $class = self::CONTEXT;
+            $context = new $class();
+            $context->field('action', 'authenticate');
+            $context->field('session_id', (string)($request->context()['session_id'] ?? ''));
+            $context->field('tenant_id', (string)($request->context()['tenant_id'] ?? ''));
+            $context->field('metadata', $request->context());
+            return $context;
+        };
+    }
+
+    private function namesFromCollection(mixed $collection, array $default = []): array
+    {
+        if (is_object($collection) && method_exists($collection, 'toArray')) {
+            $collection = $collection->toArray(true);
+        }
+        if (!Arr::is($collection)) {
+            return $default;
+        }
+
+        $names = [];
+        foreach ($collection as $item) {
+            $name = is_object($item) ? ($item->name ?? null) : $item;
+            if (Val::isNotEmpty($name)) {
+                $names[] = Str::make((string)$name)->trim()->lower()->val();
+            }
+        }
+
+        return Arr::isNotEmpty($names) ? Arr::make($names)->unique()->toArray() : $default;
+    }
+}

--- a/src/Wise/Usr/Identity.php
+++ b/src/Wise/Usr/Identity.php
@@ -8,19 +8,23 @@ use BlueFission\Arr;
 use BlueFission\Str;
 use BlueFission\Val;
 use BlueFission\Wise\Usr\Profile;
+use BlueFission\Wise\Usr\Auth\AuthProviderInterface;
+use BlueFission\Wise\Usr\Auth\AuthRequest;
 
 class Identity {
 	protected $_authenticator;
 	protected $_kernel;
+    protected ?AuthProviderInterface $_provider;
 
 	protected $_username = '';
 	protected $_password = '';
 
 	protected $_attempts = 3;
 
-	public function __construct(Kernel $kernel, Authenticator $authenticator) {
+	public function __construct(Kernel $kernel, Authenticator $authenticator, ?AuthProviderInterface $provider = null) {
 		$this->_kernel = $kernel;
 		$this->_authenticator = $authenticator;
+        $this->_provider = $provider;
 	}
 
 	public function prompt() {
@@ -60,19 +64,36 @@ class Identity {
 	}
 
 	public function authenticate($username, $password) {
+		if ($this->_provider?->available()) {
+            $this->_provider->authenticate(new AuthRequest((string)$username, (string)$password));
+            return;
+        }
 		$this->_authenticator->authenticate($username, $password);
 	}
 
 	public function logout() {
+		if ($this->_provider?->available()) {
+            $this->_provider->logout();
+            return;
+        }
 		$this->_authenticator->logout();
 	}
 
 	public function isAuthenticated() {
+		if ($this->_provider?->available()) {
+            return $this->_provider->isAuthenticated();
+        }
 		return $this->_authenticator->isAuthenticated();
 	}
 
 	public function profile(): Profile
 	{
+		$providerProfile = $this->_provider?->available()
+			? $this->_provider->profile()
+			: null;
+		if (Val::is($providerProfile)) {
+            return $providerProfile;
+        }
 		$id = '';
 		$authId = $this->_authenticator->id ?? null;
 		$authUsername = $this->_authenticator->username ?? null;

--- a/src/Wise/Usr/Profile.php
+++ b/src/Wise/Usr/Profile.php
@@ -8,11 +8,13 @@ class Profile
 {
     protected string $_id;
     protected array $_roles;
+    protected array $_permissions;
 
-    public function __construct(string $id, array $roles = ['user'])
+    public function __construct(string $id, array $roles = ['user'], array $permissions = [])
     {
         $this->_id = $id;
         $this->_roles = $roles;
+        $this->_permissions = $permissions;
     }
 
     public function id(): string
@@ -28,5 +30,15 @@ class Profile
     public function hasRole(string $role): bool
     {
         return Arr::has($this->_roles, $role, true);
+    }
+
+    public function permissions(): array
+    {
+        return $this->_permissions;
+    }
+
+    public function hasPermission(string $permission): bool
+    {
+        return Arr::has($this->_permissions, $permission, true);
     }
 }

--- a/tests/AuthProviderTest.php
+++ b/tests/AuthProviderTest.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace BlueFission\Tests;
+
+use BlueFission\Data\Storage\Memory;
+use BlueFission\Services\Authenticator;
+use BlueFission\Wise\Arc\Kernel;
+use BlueFission\Wise\Usr\Auth\AuthRequest;
+use BlueFission\Wise\Usr\Auth\NullAuthProvider;
+use BlueFission\Wise\Usr\Auth\PresenceAuthProvider;
+use BlueFission\Wise\Usr\Identity;
+use PHPUnit\Framework\TestCase;
+
+final class AuthProviderTest extends TestCase
+{
+    public function testNullProviderFailsDeterministically(): void
+    {
+        $provider = new NullAuthProvider();
+
+        $outcome = $provider->authenticate(new AuthRequest('alex', 'secret'));
+
+        $this->assertFalse($provider->available());
+        $this->assertFalse($outcome->authenticated());
+        $this->assertSame('authentication_provider_unavailable', $outcome->reason());
+        $this->assertNull($outcome->profile());
+    }
+
+    public function testPresenceProviderMapsPrincipalRolesAndPermissions(): void
+    {
+        $registry = new FakePresenceRegistry(FakePresenceResult::success(
+            new FakePresencePrincipal(
+                'user-42',
+                new FakePresenceCollection(['operator', 'reviewer']),
+                new FakePresenceCollection(['resource.read', 'resource.execute'])
+            ),
+            ['authenticator' => 'password']
+        ));
+        $provider = $this->makeProvider($registry);
+
+        $outcome = $provider->authenticate(new AuthRequest(
+            'alex',
+            'not-exported',
+            context: ['session_id' => 'session-1', 'tenant_id' => 'tenant-1']
+        ));
+
+        $this->assertTrue($provider->available());
+        $this->assertTrue($outcome->authenticated());
+        $this->assertSame('user-42', $outcome->profile()?->id());
+        $this->assertTrue($outcome->profile()?->hasRole('operator'));
+        $this->assertTrue($provider->hasPermission('resource.execute'));
+        $this->assertSame('presence', $outcome->metadata()['provider']);
+        $this->assertArrayNotHasKey('secret', $outcome->metadata());
+        $this->assertSame('not-exported', $registry->credential?->secret);
+        $this->assertSame('session-1', $registry->context?->sessionId);
+    }
+
+    public function testPresenceProviderMapsFailureWithoutPrincipal(): void
+    {
+        $provider = $this->makeProvider(new FakePresenceRegistry(
+            FakePresenceResult::failure('credential_rejected', ['attempts_remaining' => 2])
+        ));
+
+        $outcome = $provider->authenticate(new AuthRequest('alex', 'invalid'));
+
+        $this->assertFalse($outcome->authenticated());
+        $this->assertSame('credential_rejected', $outcome->reason());
+        $this->assertSame(2, $outcome->metadata()['attempts_remaining']);
+        $this->assertFalse($provider->isAuthenticated());
+    }
+
+    public function testPresenceProviderNormalizesExceptions(): void
+    {
+        $provider = $this->makeProvider(new FakePresenceRegistry(exception: new \RuntimeException('offline')));
+
+        $outcome = $provider->authenticate(new AuthRequest('alex', 'secret'));
+
+        $this->assertFalse($outcome->authenticated());
+        $this->assertSame('presence_authentication_failed', $outcome->reason());
+        $this->assertSame(\RuntimeException::class, $outcome->metadata()['exception']);
+        $this->assertArrayNotHasKey('secret', $outcome->metadata());
+    }
+
+    public function testIdentityUsesConfiguredProviderAndReturnsToGuestAfterLogout(): void
+    {
+        $provider = $this->makeProvider(new FakePresenceRegistry(FakePresenceResult::success(
+            new FakePresencePrincipal(
+                'user-42',
+                new FakePresenceCollection(['operator']),
+                new FakePresenceCollection(['resource.read'])
+            )
+        )));
+        $identity = new Identity(
+            new FakeKernelForAuthProvider(),
+            new Authenticator(new Memory(), new Memory()),
+            $provider
+        );
+
+        $identity->authenticate('alex', 'secret');
+
+        $this->assertTrue($identity->isAuthenticated());
+        $this->assertSame('user-42', $identity->profile()->id());
+        $this->assertTrue($identity->profile()->hasPermission('resource.read'));
+
+        $identity->logout();
+
+        $this->assertFalse($identity->isAuthenticated());
+        $this->assertSame('guest', $identity->profile()->id());
+    }
+
+    private function makeProvider(FakePresenceRegistry $registry): PresenceAuthProvider
+    {
+        return new PresenceAuthProvider(
+            $registry,
+            static fn (AuthRequest $request): object => (object)[
+                'type' => $request->type(),
+                'identifier' => $request->identifier(),
+                'secret' => $request->secret(),
+                'metadata' => $request->context(),
+            ],
+            static fn (AuthRequest $request): object => (object)[
+                'sessionId' => $request->context()['session_id'] ?? '',
+                'tenantId' => $request->context()['tenant_id'] ?? '',
+                'metadata' => $request->context(),
+            ]
+        );
+    }
+}
+
+final class FakeKernelForAuthProvider extends Kernel
+{
+    public function __construct()
+    {
+    }
+}
+
+final class FakePresenceRegistry
+{
+    public ?object $credential = null;
+    public ?object $context = null;
+
+    public function __construct(
+        private ?FakePresenceResult $result = null,
+        private ?\Throwable $exception = null
+    ) {
+    }
+
+    public function authenticate(object $credential, object $context): FakePresenceResult
+    {
+        $this->credential = $credential;
+        $this->context = $context;
+
+        if ($this->exception) {
+            throw $this->exception;
+        }
+
+        return $this->result ?? FakePresenceResult::failure('authentication_failed');
+    }
+}
+
+final class FakePresenceResult
+{
+    public function __construct(
+        private bool $successful,
+        public ?FakePresencePrincipal $principal,
+        public string $reason,
+        public array $metadata = []
+    ) {
+    }
+
+    public static function success(FakePresencePrincipal $principal, array $metadata = []): self
+    {
+        return new self(true, $principal, 'authenticated', $metadata);
+    }
+
+    public static function failure(string $reason, array $metadata = []): self
+    {
+        return new self(false, null, $reason, $metadata);
+    }
+
+    public function isSuccessful(): bool
+    {
+        return $this->successful;
+    }
+}
+
+final class FakePresencePrincipal
+{
+    public function __construct(
+        private string $id,
+        private FakePresenceCollection $roles,
+        private FakePresenceCollection $permissions
+    ) {
+    }
+
+    public function id(): string
+    {
+        return $this->id;
+    }
+
+    public function roles(): FakePresenceCollection
+    {
+        return $this->roles;
+    }
+
+    public function permissions(): FakePresenceCollection
+    {
+        return $this->permissions;
+    }
+}
+
+final class FakePresenceCollection
+{
+    public function __construct(private array $names)
+    {
+    }
+
+    public function toArray(bool $allowEmpty = false): array
+    {
+        return array_map(
+            static fn (string $name): object => (object)['name' => $name],
+            $this->names
+        );
+    }
+}


### PR DESCRIPTION
## Intent

Add a package-neutral authentication provider contract and an optional Presence adapter so advanced authentication can supply Wise identity, role, and permission data without replacing the existing clean-install authenticator.

## User Stories / Acceptance Criteria

- As a shell integrator, I can inject an advanced authenticator through a stable Wise-owned interface.
- Successful authentication maps principal identity, roles, and permissions into `Profile`.
- Authentication failure and provider exceptions produce deterministic outcomes.
- Credential secrets are not copied into profiles, outcomes, or diagnostic metadata.
- When the optional package is absent or unconfigured, the existing authenticator remains active.
- No VCS-only Composer dependency is introduced.

## Key Files

- `src/Wise/Usr/Auth/AuthProviderInterface.php`
- `src/Wise/Usr/Auth/PresenceAuthProvider.php`
- `src/Wise/Usr/Auth/AuthRequest.php`
- `src/Wise/Usr/Auth/AuthOutcome.php`
- `src/Wise/Usr/Identity.php`
- `src/Wise/Usr/Profile.php`
- `AUTHENTICATION.md`
- `tests/AuthProviderTest.php`

## How To Test

```powershell
vendor\bin\phpunit.bat --do-not-cache-result tests\AuthProviderTest.php tests\IdentityProfileTest.php
vendor\bin\phpunit.bat --do-not-cache-result
```

Focused result: 7 tests, 31 assertions.

Full result: 189 tests, 454 assertions, one expected skip, six upstream PHPUnit deprecations.

## QA Checklist

- [x] Provider absent path is deterministic.
- [x] Successful principal mapping is covered.
- [x] Roles and permissions are normalized.
- [x] Denial and exception paths are covered.
- [x] Secret confinement is asserted.
- [x] Existing identity behavior remains covered.
- [x] Full suite passes on PHP 8.2.

## Approval Conditions

- Confirm the Wise-owned provider boundary is suitable for optional authentication integrations.
- Confirm package activation should remain configuration-driven until a tagged dependency can be consumed from Packagist.

Advances #17.
