### PR TITLE
Add Automata orchestration adapter

### DIFF
--- a/INTELLIGENCE.md
+++ b/INTELLIGENCE.md
@@ -1,0 +1,16 @@
+# Intelligence And Orchestration
+
+Wise exposes intelligence execution through the package-owned `IOrchestrator` contract. Commands and resources submit an `OrchestrationRequest` and consume an `OrchestrationOutcome`; they do not depend on prompt text or a concrete agent runtime.
+
+`AutomataOrchestrator` delegates orchestration patterns, session scope, capabilities, and agent state to released Automata APIs. Wise owns only shell-facing normalization:
+
+- `PersonaContext` maps identity, roles, permissions, and application attributes into a stable context.
+- `OrchestrationRequest` carries the task, workers, pattern, scoped context, capabilities, prior state, and configuration.
+- `OrchestrationOutcome` preserves status, output, worker results, conflicts, confidence, metadata, persona, session id, and a recoverable state snapshot.
+- `NullOrchestrator` provides a deterministic unavailable result for disabled or minimal runtimes.
+
+The adapter emits DevElation hooks at `wise.int.orchestration.before`, `wise.int.orchestration.after`, and `wise.int.orchestration.failed`. Hook handlers must not place secrets in context or result metadata.
+
+Workers are ordinary Automata orchestration workers. They should return structured arrays with `output`, optional `confidence`, and optional `metadata`. Host code remains responsible for registering tools and enforcing authorization before a worker performs mutations.
+
+Persona and session context are snapshots. They do not grant permissions by themselves. The request capability list controls the Automata session scope, while resource and command authorization remains at the Wise execution boundary.

--- a/src/Wise/Int/AutomataOrchestrator.php
+++ b/src/Wise/Int/AutomataOrchestrator.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace BlueFission\Wise\Int;
+
+use BlueFission\Arr;
+use BlueFission\Automata\LLM\Agent\AgentSession;
+use BlueFission\Automata\LLM\Agent\Orchestration\OrchestrationConfig;
+use BlueFission\Automata\LLM\Agent\Orchestration\Orchestrator;
+use BlueFission\Automata\LLM\Agent\State\AgentState;
+use BlueFission\DevElation as Dev;
+use BlueFission\Func;
+use BlueFission\Obj;
+use BlueFission\Str;
+
+class AutomataOrchestrator extends Obj implements IOrchestrator
+{
+    private $factory;
+    private bool $enabled;
+
+    public function __construct(?callable $factory = null, bool $enabled = true)
+    {
+        parent::__construct();
+        $this->factory = $factory ?? static fn (array $config): Orchestrator => new Orchestrator($config);
+        $this->enabled = $enabled;
+    }
+
+    public function available(): bool
+    {
+        return $this->enabled
+            && class_exists(Orchestrator::class)
+            && class_exists(AgentSession::class)
+            && class_exists(AgentState::class)
+            && Func::isCallable($this->factory);
+    }
+
+    public function orchestrate(OrchestrationRequest $request): OrchestrationOutcome
+    {
+        if (!$this->available()) {
+            return OrchestrationOutcome::unavailable();
+        }
+
+        $persona = $request->persona()->toArray();
+        $session = new AgentSession($request->sessionId(), [
+            'persona' => $persona,
+            'context' => $request->context(),
+        ]);
+        foreach ($request->capabilities() as $capability) {
+            $name = Str::make((string)$capability)->trim()->lower()->val();
+            if (Str::isNotEmpty($name)) {
+                $session->allow($name);
+            }
+        }
+
+        $state = new AgentState($request->state());
+        $state->write(AgentState::RULES, 'persona', $persona);
+        $state->write(AgentState::OBSERVATIONS, 'task', $request->task());
+
+        $input = Arr::make($request->context())->merge([
+            'task' => $request->task(),
+            'persona' => $persona,
+            'session' => [
+                'id' => $session->id(),
+                'capabilities' => $request->capabilities(),
+                'context' => $session->context(),
+            ],
+            'state' => $state->snapshot(),
+        ])->toArray();
+        $config = Arr::make($request->config())->merge([
+            'pattern' => $request->pattern() ?: OrchestrationConfig::SEQUENTIAL,
+            'workers' => $request->workers(),
+        ])->toArray();
+
+        Dev::do('wise.int.orchestration.before', [$request, $input, $config]);
+
+        try {
+            $orchestrator = ($this->factory)($config);
+            if (!($orchestrator instanceof Orchestrator)) {
+                return OrchestrationOutcome::failure('invalid_automata_orchestrator');
+            }
+            $data = $orchestrator->run($input)->toArray();
+        } catch (\Throwable $exception) {
+            $outcome = OrchestrationOutcome::failure('automata_orchestration_failed', [
+                'exception' => $exception::class,
+            ]);
+            Dev::do('wise.int.orchestration.failed', [$outcome]);
+            return $outcome;
+        }
+
+        $outcome = new OrchestrationOutcome(Arr::make($data)->merge([
+            'persona' => $persona,
+            'session_id' => $session->id(),
+            'state' => $state->snapshot(),
+        ])->toArray());
+        Dev::do('wise.int.orchestration.after', [$outcome]);
+
+        return $outcome;
+    }
+}

--- a/src/Wise/Int/IOrchestrator.php
+++ b/src/Wise/Int/IOrchestrator.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace BlueFission\Wise\Int;
+
+interface IOrchestrator
+{
+    public function available(): bool;
+
+    public function orchestrate(OrchestrationRequest $request): OrchestrationOutcome;
+}

--- a/src/Wise/Int/NullOrchestrator.php
+++ b/src/Wise/Int/NullOrchestrator.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace BlueFission\Wise\Int;
+
+use BlueFission\Obj;
+
+class NullOrchestrator extends Obj implements IOrchestrator
+{
+    public function available(): bool
+    {
+        return false;
+    }
+
+    public function orchestrate(OrchestrationRequest $request): OrchestrationOutcome
+    {
+        return OrchestrationOutcome::unavailable();
+    }
+}

--- a/src/Wise/Int/OrchestrationOutcome.php
+++ b/src/Wise/Int/OrchestrationOutcome.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace BlueFission\Wise\Int;
+
+use BlueFission\Arr;
+use BlueFission\Obj;
+use BlueFission\Str;
+use BlueFission\Val;
+
+class OrchestrationOutcome extends Obj
+{
+    private Str $status;
+    private Str $pattern;
+    private mixed $output;
+    private Arr $workerResults;
+    private Arr $conflicts;
+    private ?float $confidence;
+    private Arr $metadata;
+    private Arr $persona;
+    private Str $sessionId;
+    private Arr $state;
+
+    public function __construct(array $data = [])
+    {
+        parent::__construct();
+        $this->status = Str::make((string)($data['status'] ?? 'failed'));
+        $this->pattern = Str::make((string)($data['pattern'] ?? ''));
+        $this->output = $data['output'] ?? null;
+        $this->workerResults = Arr::make(Arr::is($data['worker_results'] ?? null) ? $data['worker_results'] : []);
+        $this->conflicts = Arr::make(Arr::is($data['conflicts'] ?? null) ? $data['conflicts'] : []);
+        $this->confidence = Val::is($data['confidence'] ?? null) ? (float)$data['confidence'] : null;
+        $this->metadata = Arr::make(Arr::is($data['metadata'] ?? null) ? $data['metadata'] : []);
+        $this->persona = Arr::make(Arr::is($data['persona'] ?? null) ? $data['persona'] : []);
+        $this->sessionId = Str::make((string)($data['session_id'] ?? ''));
+        $this->state = Arr::make(Arr::is($data['state'] ?? null) ? $data['state'] : []);
+    }
+
+    public static function unavailable(): self
+    {
+        return new self([
+            'status' => 'unavailable',
+            'metadata' => ['reason' => 'automata_orchestration_unavailable'],
+        ]);
+    }
+
+    public static function failure(string $reason, array $metadata = []): self
+    {
+        return new self([
+            'status' => 'failed',
+            'metadata' => Arr::make($metadata)->merge(['reason' => $reason])->toArray(),
+        ]);
+    }
+
+    public function status(): string
+    {
+        return $this->status->val();
+    }
+
+    public function successful(): bool
+    {
+        return Arr::has(['completed', 'success'], $this->status(), true);
+    }
+
+    public function pattern(): string
+    {
+        return $this->pattern->val();
+    }
+
+    public function output(): mixed
+    {
+        return $this->output;
+    }
+
+    public function workerResults(): array
+    {
+        return $this->workerResults->toArray();
+    }
+
+    public function conflicts(): array
+    {
+        return $this->conflicts->toArray();
+    }
+
+    public function confidence(): ?float
+    {
+        return $this->confidence;
+    }
+
+    public function metadata(): array
+    {
+        return $this->metadata->toArray();
+    }
+
+    public function persona(): array
+    {
+        return $this->persona->toArray();
+    }
+
+    public function sessionId(): string
+    {
+        return $this->sessionId->val();
+    }
+
+    public function state(): array
+    {
+        return $this->state->toArray();
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status(),
+            'pattern' => $this->pattern(),
+            'output' => $this->output(),
+            'worker_results' => $this->workerResults(),
+            'conflicts' => $this->conflicts(),
+            'confidence' => $this->confidence(),
+            'metadata' => $this->metadata(),
+            'persona' => $this->persona(),
+            'session_id' => $this->sessionId(),
+            'state' => $this->state(),
+        ];
+    }
+}

--- a/src/Wise/Int/OrchestrationRequest.php
+++ b/src/Wise/Int/OrchestrationRequest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace BlueFission\Wise\Int;
+
+use BlueFission\Arr;
+use BlueFission\Obj;
+use BlueFission\Str;
+use BlueFission\Wise\Usr\Profile;
+
+class OrchestrationRequest extends Obj
+{
+    private Str $task;
+    private PersonaContext $persona;
+    private Str $pattern;
+    private Str $sessionId;
+    private Arr $context;
+    private Arr $workers;
+    private Arr $capabilities;
+    private Arr $state;
+    private Arr $config;
+
+    public function __construct(
+        string $task,
+        Profile|PersonaContext $persona,
+        array $workers = [],
+        string $pattern = 'sequential',
+        array $context = [],
+        array $capabilities = [],
+        array $state = [],
+        array $config = [],
+        ?string $sessionId = null
+    ) {
+        parent::__construct();
+        $this->task = Str::make($task)->trim();
+        $this->persona = $persona instanceof PersonaContext
+            ? $persona
+            : PersonaContext::fromProfile($persona);
+        $this->pattern = Str::make($pattern)->trim()->lower();
+        $this->sessionId = Str::make($sessionId ?? '')->trim();
+        $this->context = Arr::make($context);
+        $this->workers = Arr::make($workers);
+        $this->capabilities = Arr::make($capabilities);
+        $this->state = Arr::make($state);
+        $this->config = Arr::make($config);
+    }
+
+    public function task(): string
+    {
+        return $this->task->val();
+    }
+
+    public function persona(): PersonaContext
+    {
+        return $this->persona;
+    }
+
+    public function pattern(): string
+    {
+        return $this->pattern->val();
+    }
+
+    public function sessionId(): ?string
+    {
+        return $this->sessionId->isNotEmpty() ? $this->sessionId->val() : null;
+    }
+
+    public function context(): array
+    {
+        return $this->context->toArray();
+    }
+
+    public function workers(): array
+    {
+        return $this->workers->toArray();
+    }
+
+    public function capabilities(): array
+    {
+        return $this->capabilities->toArray();
+    }
+
+    public function state(): array
+    {
+        return $this->state->toArray();
+    }
+
+    public function config(): array
+    {
+        return $this->config->toArray();
+    }
+}

--- a/src/Wise/Int/PersonaContext.php
+++ b/src/Wise/Int/PersonaContext.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace BlueFission\Wise\Int;
+
+use BlueFission\Arr;
+use BlueFission\Obj;
+use BlueFission\Str;
+use BlueFission\Wise\Usr\Profile;
+
+class PersonaContext extends Obj
+{
+    private Str $id;
+    private Arr $roles;
+    private Arr $permissions;
+    private Arr $attributes;
+
+    public function __construct(string $id, array $roles = [], array $permissions = [], array $attributes = [])
+    {
+        parent::__construct();
+        $this->id = Str::make($id)->trim();
+        $this->roles = Arr::make($this->normalizeNames($roles));
+        $this->permissions = Arr::make($this->normalizeNames($permissions));
+        $this->attributes = Arr::make($attributes);
+    }
+
+    public static function fromProfile(Profile $profile, array $attributes = []): self
+    {
+        $permissions = method_exists($profile, 'permissions') ? $profile->permissions() : [];
+
+        return new self($profile->id(), $profile->roles(), $permissions, $attributes);
+    }
+
+    public function id(): string
+    {
+        return $this->id->val();
+    }
+
+    public function roles(): array
+    {
+        return $this->roles->toArray();
+    }
+
+    public function permissions(): array
+    {
+        return $this->permissions->toArray();
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id(),
+            'roles' => $this->roles(),
+            'permissions' => $this->permissions(),
+            'attributes' => $this->attributes->toArray(),
+        ];
+    }
+
+    private function normalizeNames(array $values): array
+    {
+        $names = [];
+        foreach ($values as $value) {
+            $name = Str::make((string)$value)->trim()->lower()->val();
+            if (Str::isNotEmpty($name)) {
+                $names[] = $name;
+            }
+        }
+
+        return Arr::make($names)->unique()->values()->toArray();
+    }
+}

--- a/tests/AutomataOrchestratorTest.php
+++ b/tests/AutomataOrchestratorTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace BlueFission\Tests;
+
+use BlueFission\Wise\Int\AutomataOrchestrator;
+use BlueFission\Wise\Int\NullOrchestrator;
+use BlueFission\Wise\Int\OrchestrationRequest;
+use BlueFission\Wise\Int\PersonaContext;
+use BlueFission\Wise\Usr\Profile;
+use PHPUnit\Framework\TestCase;
+
+final class AutomataOrchestratorTest extends TestCase
+{
+    public function testPersonaContextNormalizesProfileData(): void
+    {
+        $persona = PersonaContext::fromProfile(
+            new Profile('agent-1', ['Planner', ' planner ', 'Reviewer']),
+            ['mode' => 'careful']
+        );
+
+        $this->assertSame('agent-1', $persona->id());
+        $this->assertSame(['planner', 'reviewer'], $persona->roles());
+        $this->assertSame([], $persona->permissions());
+        $this->assertSame('careful', $persona->toArray()['attributes']['mode']);
+    }
+
+    public function testNullOrchestratorReturnsUnavailableOutcome(): void
+    {
+        $orchestrator = new NullOrchestrator();
+
+        $outcome = $orchestrator->orchestrate(new OrchestrationRequest(
+            'inspect the workspace',
+            new Profile('agent-1')
+        ));
+
+        $this->assertFalse($orchestrator->available());
+        $this->assertSame('unavailable', $outcome->status());
+        $this->assertSame('automata_orchestration_unavailable', $outcome->metadata()['reason']);
+    }
+
+    public function testAutomataSequentialOrchestrationReturnsStructuredState(): void
+    {
+        $orchestrator = new AutomataOrchestrator();
+        $request = new OrchestrationRequest(
+            'prepare and verify a change',
+            new Profile('agent-1', ['operator']),
+            workers: [
+                'plan' => static fn (array $context): array => [
+                    'output' => ['steps' => ['inspect', 'change', 'verify']],
+                    'confidence' => 0.9,
+                ],
+                'verify' => static fn (array $context, array $prior): array => [
+                    'output' => [
+                        'verified' => isset($context['plan']['steps']),
+                        'prior_count' => count($prior),
+                    ],
+                    'confidence' => 1.0,
+                ],
+            ],
+            context: ['workspace' => 'current'],
+            capabilities: ['Resource.Read', 'resource.execute'],
+            sessionId: 'session-1'
+        );
+
+        $outcome = $orchestrator->orchestrate($request);
+
+        $this->assertTrue($orchestrator->available());
+        $this->assertTrue($outcome->successful());
+        $this->assertSame('sequential', $outcome->pattern());
+        $this->assertSame([], $outcome->conflicts());
+        $this->assertSame(0.95, $outcome->confidence());
+        $this->assertSame('session-1', $outcome->sessionId());
+        $this->assertSame('agent-1', $outcome->persona()['id']);
+        $this->assertCount(2, $outcome->workerResults());
+        $this->assertTrue($outcome->output()['verify']['verified']);
+        $this->assertSame('prepare and verify a change', $outcome->state()['channels']['observations']['task']);
+        $this->assertSame('agent-1', $outcome->state()['channels']['rules']['persona']['id']);
+    }
+
+    public function testAutomataOrchestrationCanBeDisabled(): void
+    {
+        $orchestrator = new AutomataOrchestrator(enabled: false);
+
+        $outcome = $orchestrator->orchestrate(new OrchestrationRequest('task', new Profile('agent-1')));
+
+        $this->assertFalse($orchestrator->available());
+        $this->assertSame('unavailable', $outcome->status());
+    }
+
+    public function testAutomataFactoryFailuresAreNormalized(): void
+    {
+        $orchestrator = new AutomataOrchestrator(
+            static function (array $config): object {
+                throw new \RuntimeException('runtime details');
+            }
+        );
+
+        $outcome = $orchestrator->orchestrate(new OrchestrationRequest('task', new Profile('agent-1')));
+
+        $this->assertSame('failed', $outcome->status());
+        $this->assertSame('automata_orchestration_failed', $outcome->metadata()['reason']);
+        $this->assertSame(\RuntimeException::class, $outcome->metadata()['exception']);
+        $this->assertStringNotContainsString('runtime details', json_encode($outcome->toArray()));
+    }
+
+    public function testAutomataFactoryMustReturnReleasedOrchestrator(): void
+    {
+        $orchestrator = new AutomataOrchestrator(static fn (array $config): object => new \stdClass());
+
+        $outcome = $orchestrator->orchestrate(new OrchestrationRequest('task', new Profile('agent-1')));
+
+        $this->assertSame('failed', $outcome->status());
+        $this->assertSame('invalid_automata_orchestrator', $outcome->metadata()['reason']);
+    }
+}


### PR DESCRIPTION
## Intent

Expose reusable Wise intelligence and automation contracts backed by Automata's released orchestration, session, and agent-state APIs.

## User Stories / Acceptance Criteria

- As a shell integrator, I can submit a structured task through a Wise-owned orchestration interface.
- Persona identity, roles, permissions, and attributes are normalized before runtime execution.
- Automata owns execution patterns, session scope, and recoverable agent state.
- Commands and resources receive structured status, output, worker results, conflicts, confidence, metadata, persona, session, and state data.
- Disabled, invalid, and failed runtime paths return deterministic outcomes.
- DevElation hooks expose before, after, and failure lifecycle points.

## Key Files

- `src/Wise/Int/IOrchestrator.php`
- `src/Wise/Int/AutomataOrchestrator.php`
- `src/Wise/Int/NullOrchestrator.php`
- `src/Wise/Int/OrchestrationRequest.php`
- `src/Wise/Int/OrchestrationOutcome.php`
- `src/Wise/Int/PersonaContext.php`
- `INTELLIGENCE.md`
- `tests/AutomataOrchestratorTest.php`

## How To Test

```powershell
vendor\bin\phpunit.bat --do-not-cache-result tests\AutomataOrchestratorTest.php
vendor\bin\phpunit.bat --do-not-cache-result
```

Focused result: 6 tests, 26 assertions.

Full result: 190 tests, 454 assertions, one expected skip, six upstream PHPUnit deprecations.

## QA Checklist

- [x] Released Automata sequential orchestration executes through the adapter.
- [x] Persona data is normalized and deduplicated.
- [x] Session capabilities and context are scoped.
- [x] Recoverable agent-state snapshots are returned.
- [x] Disabled, invalid-factory, and exception paths are deterministic.
- [x] Exception messages are excluded from public outcomes.
- [x] Full suite passes on PHP 8.2.

## Approval Conditions

- Confirm the `Int` namespace and package-owned request/outcome boundary fit Wise's low-level module conventions.
- Confirm host authorization remains outside persona metadata and Automata session context.

Closes #18.
