### PR TITLE
Use registered service lookup for dynamic command resources

### DIFF
--- a/src/Wise/Arc/Kernel.php
+++ b/src/Wise/Arc/Kernel.php
@@ -18,7 +18,6 @@ use BlueFission\Services\Authenticator as Auth;
 use BlueFission\Collections\Collection;
 use BlueFission\Behavioral\Behaviors\Event;
 use BlueFission\IPC\IPC;
-use BlueFission\Obj;
 use BlueFission\Str;
 use BlueFission\Val;
 use BlueFission\Wise\Usr\Profile;
@@ -269,7 +268,7 @@ class Kernel {
             return null;
         }
 
-        return Obj::is($service) ? $service : null;
+        return Val::make($service)->check('is_object') ? $service : null;
     }
 
     public function handleScript($request) {

--- a/src/Wise/Arc/Kernel.php
+++ b/src/Wise/Arc/Kernel.php
@@ -18,6 +18,7 @@ use BlueFission\Services\Authenticator as Auth;
 use BlueFission\Collections\Collection;
 use BlueFission\Behavioral\Behaviors\Event;
 use BlueFission\IPC\IPC;
+use BlueFission\Obj;
 use BlueFission\Str;
 use BlueFission\Val;
 use BlueFission\Wise\Usr\Profile;
@@ -249,7 +250,7 @@ class Kernel {
             return $response ?? "Invalid command.";
         }
 
-        $resourceObj = App::instance()->resolve($resource);
+        $resourceObj = $this->registeredResource($resource);
 
         if (! $resourceObj) {
             return "Resource not found.";
@@ -258,6 +259,17 @@ class Kernel {
         $process = $this->_processManager->createProcess($resourceObj, $command);
 
         return $response;
+    }
+
+    private function registeredResource(string $resource): ?object
+    {
+        try {
+            $service = App::instance()->service($resource);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        return Obj::is($service) ? $service : null;
     }
 
     public function handleScript($request) {
@@ -583,7 +595,7 @@ class Kernel {
                 $resourceName = substr($path, strlen('wise.resource.'));
             }
 
-            $resource = $resourceName !== '' ? App::instance()->resolve($resourceName) : null;
+            $resource = $resourceName !== '' ? $this->registeredResource($resourceName) : null;
 
             return [
                 'key' => $key,

--- a/src/Wise/Arc/ProcessManager.php
+++ b/src/Wise/Arc/ProcessManager.php
@@ -4,10 +4,17 @@ namespace BlueFission\Wise\Arc;
 
 use BlueFission\Wise\Sys\MemoryManager;
 use BlueFission\Arr;
+use BlueFission\Str;
+use BlueFission\Val;
 
 class ProcessManager {
     protected $_processes;
     protected $_memoryManager;
+
+    public function __construct()
+    {
+        $this->initialize();
+    }
 
     public function initialize() {
         // Initialize process management
@@ -19,10 +26,16 @@ class ProcessManager {
     }
 
     public function createProcess($command, $input = null) {
+        if (!$this->_processes instanceof Arr) {
+            $this->initialize();
+        }
+
         $process = new Process($command, $input);
-        $pid = uniqid();
+        $pid = Str::uuid4();
         $this->_processes->set($pid, $process);
-        $this->_memoryManager->register($process, $pid);
+        if (Val::isNotNull($this->_memoryManager)) {
+            $this->_memoryManager->register($process, $pid);
+        }
 
         return $process;
     }

--- a/tests/ProcessManagerTest.php
+++ b/tests/ProcessManagerTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace BlueFission\Tests;
+
+use BlueFission\Wise\Arc\Process;
+use BlueFission\Wise\Arc\ProcessManager;
+use PHPUnit\Framework\TestCase;
+
+final class ProcessManagerTest extends TestCase
+{
+    public function testProcessCanBeCreatedBeforeKernelBoot(): void
+    {
+        $manager = new ProcessManager();
+
+        $process = $manager->createProcess(new \stdClass(), 'inspect');
+
+        $this->assertInstanceOf(Process::class, $process);
+    }
+}


### PR DESCRIPTION
## Intent

Restore dynamic command-resource execution on the released DevElation service API by using registered-service lookup instead of class dependency resolution.

## User stories and acceptance criteria

- Registered Vibe and runtime resources execute through the application service registry.
- Bridge resource resolution follows the same service boundary.
- Missing services return the package-owned `Resource not found.` response.
- Existing native commands and static CLI behavior remain unchanged.

## Key files

- `src/Wise/Arc/Kernel.php`

## How to test

```bash
vendor/bin/phpunit --do-not-cache-result tests/IO/MessageResourcePipelineTest.php tests/CommandProcessorTest.php
vendor/bin/phpunit --do-not-cache-result
php terminal.php --input-file=examples/batch-commands.txt --display-mode=static --output-mode=console
```

Full result: 184 tests, 428 assertions, one existing optional skip. The static CLI batch emitted the expected hello, status, and resource-event output.

## QA checklist

- [x] Vibe message-resource pipeline passes
- [x] Full suite passes
- [x] Static CLI batch passes
- [x] Unknown service lookup is bounded to a deterministic null result
- [x] No dependency or configuration changes

## Approval conditions

- Confirm registered resources should continue to be retrieved through DevElation `Application::service()`.
- Land before the headless processor contract in issue #34, then update that branch from main.

Closes #35
