### PR TITLE
Refresh released intelligence runtime dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "bluefission/develation": "^1.3.41",
+        "bluefission/develation": "^1.3.42",
         "bluefission/automata": "^1.0.0-alpha.2",
         "bluefission/simpleclients": "^0.1.0-alpha",
-        "bluefission/synthetiq": "^0.1.0-alpha",
+        "bluefission/synthetiq": "^0.1.0-alpha.1",
         "bluefission/jenerator": "dev-main",
         "bluefission/vibrato": "dev-main",
         "google/cloud-language": "^0.27.0",


### PR DESCRIPTION
## Intent

Raise Wise's released intelligence runtime dependency floors while preserving the current interpreter and command-processing contracts.

Closes #40.

## User Stories And Acceptance Criteria

- [x] Consume DevElation `^1.3.42` from its released package.
- [x] Consume SynthetiQ `^0.1.0-alpha.1` from its released package.
- [x] Retain the current Vibrato `dev-main` contract and resolve its current reviewed head.
- [x] Preserve the existing Automata, Jenerator, and SimpleClients compatibility set.
- [x] Keep local repository paths and workstation-specific Composer configuration out of the package metadata.
- [ ] Confirm a clean Packagist solve and security audit in CI.

## Resolved Baseline

- DevElation `v1.3.42` (`9731b85`)
- SynthetiQ `v0.1.0-alpha.1` (`666ac8f`)
- Vibrato `dev-main` (`3df161b`)
- Automata `v1.0.0-alpha.3` (`c48adfd`)
- Jenerator `dev-main` (`1104094`)
- SimpleClients `v0.1.0-alpha` (`0efa8e3`)

## Key Files Changed

- `composer.json`: raises the released DevElation and SynthetiQ constraints.

## How To Test

```powershell
composer validate --strict --no-check-lock
composer check-platform-reqs
vendor\bin\phpunit.bat --do-not-cache-result
php examples\headless-command.php
php terminal.php --input-file=examples\batch-commands.txt --display-mode=static --output-mode=console
composer audit
```

## QA Checklist

- [x] Focused intelligence and interpreter coverage: 60 tests, 131 assertions.
- [x] Full local suite: 217 tests, 561 assertions.
- [x] Headless command example passes.
- [x] Static batch CLI example passes.
- [x] Composer metadata and platform requirements pass.
- [x] No local VCS paths are committed.
- [ ] Clean CI installation and advisory audit pass against public registries.

Local public DNS could not resolve Packagist or GitHub during verification. The exact released set was solved from the registered upstream checkouts, while CI remains the authoritative clean-registry installation and audit proof.

## Approval Conditions

Merge only after the PHP 8.2, PHP 8.3, analysis, clean Composer installation, and advisory checks are green, and after review confirms the resolved package set above.
