### PR TITLE
Align FileResource namespace with its resource path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
           export COMPOSER_AUTH="{\"github-oauth\":{\"github.com\":\"${GH_REPO_TOKEN}\"}}"
           composer install --no-interaction --no-progress --prefer-dist
 
+      - name: Verify authoritative PSR-4 autoloading
+        run: composer dump-autoload --classmap-authoritative --strict-psr
+
       - name: Check platform requirements
         run: composer check-platform-reqs
 

--- a/src/Wise/Commands/FileResource.php
+++ b/src/Wise/Commands/FileResource.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace BlueFission\Wise\Commands;
+
+/**
+ * @deprecated Use BlueFission\Wise\Res\FileResource.
+ */
+class FileResource extends \BlueFission\Wise\Res\FileResource
+{
+}

--- a/src/Wise/Res/FileResource.php
+++ b/src/Wise/Res/FileResource.php
@@ -1,5 +1,6 @@
 <?php
-namespace BlueFission\Wise\Commands;
+
+namespace BlueFission\Wise\Res;
 
 use BlueFission\Services\Service;
 use BlueFission\Data\FileSystem;

--- a/tests/Res/ResourceStorageRootTest.php
+++ b/tests/Res/ResourceStorageRootTest.php
@@ -2,9 +2,12 @@
 
 namespace BlueFission\Tests\Res;
 
-use BlueFission\Wise\Commands\FileResource;
+use BlueFission\Services\Application as App;
+use BlueFission\Str;
+use BlueFission\Wise\Commands\FileResource as LegacyFileResource;
 use BlueFission\Wise\Res\ActionResource;
 use BlueFission\Wise\Res\APIResource;
+use BlueFission\Wise\Res\FileResource;
 use BlueFission\Wise\Res\NoteResource;
 use BlueFission\Wise\Res\ScheduleResource;
 use BlueFission\Wise\Res\StepResource;
@@ -15,6 +18,7 @@ use BlueFission\Wise\Sys\StorageRoot;
 use BlueFission\Val;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use ReflectionProperty;
 
 class ResourceStorageRootTest extends TestCase
@@ -71,6 +75,44 @@ class ResourceStorageRootTest extends TestCase
             'todo' => [TodoResource::class, 'system', '_storage'],
             'variable' => [VariableResource::class, 'system', '_storage'],
         ];
+    }
+
+    public function testCanonicalFileResourceLoadsFromItsPsr4Path(): void
+    {
+        $reflection = new ReflectionClass(FileResource::class);
+        $path = Str::make((string)$reflection->getFileName())
+            ->replace('\\', '/')
+            ->val();
+
+        $this->assertSame(FileResource::class, $reflection->getName());
+        $this->assertStringEndsWith('/src/Wise/Res/FileResource.php', $path);
+    }
+
+    public function testLegacyFileResourceUsesItsOwnCompatibilityPath(): void
+    {
+        $reflection = new ReflectionClass(LegacyFileResource::class);
+        $path = Str::make((string)$reflection->getFileName())
+            ->replace('\\', '/')
+            ->val();
+
+        $this->assertTrue($reflection->isSubclassOf(FileResource::class));
+        $this->assertStringEndsWith('/src/Wise/Commands/FileResource.php', $path);
+    }
+
+    public function testCanonicalFileResourceResolvesThroughApplicationDelegation(): void
+    {
+        $serviceName = Str::make('file-resource-')
+            ->append(Str::make()->rand()->val())
+            ->val();
+        $storageRoot = new StorageRoot($this->root);
+
+        App::instance()->delegate($serviceName, FileResource::class, [$storageRoot]);
+        $resource = App::instance()->service($serviceName);
+
+        $this->assertInstanceOf(FileResource::class, $resource);
+        $this->assertTrue(DirectoryManager::pathExists(
+            $this->root . DIRECTORY_SEPARATOR . 'files'
+        ));
     }
 
     private function removeDirectory(string $path): void


### PR DESCRIPTION
## Intent

Make `BlueFission\Wise\Res\FileResource` the canonical PSR-4 class while preserving the historical `BlueFission\Wise\Commands\FileResource` symbol without duplicate declarations.

Closes #42.

## User Stories And Acceptance Criteria

- [x] The canonical resource loads from `src/Wise/Res/FileResource.php`.
- [x] The historical symbol remains available from its own PSR-4-compatible file.
- [x] Canonical and compatibility symbols can load in the same process without a duplicate-class fatal.
- [x] DevElation application delegation resolves the canonical resource with explicit constructor arguments.
- [x] Optimized authoritative Composer autoloading is validated in CI.
- [x] Focused and full regression suites pass locally on PHP 8.2.
- [ ] PHP 8.2 and PHP 8.3 CI pass from a clean dependency installation.

## Root Cause

The resource was moved from the historical command namespace into `src/Wise/Res`, but its declaration retained `BlueFission\Wise\Commands`. Composer's combined PSR-4 and classmap loading could therefore include the same file for competing symbols and fatally redeclare the legacy class.

## Key Files Changed

- `src/Wise/Res/FileResource.php`: declares the canonical `BlueFission\Wise\Res` namespace.
- `src/Wise/Commands/FileResource.php`: provides the deprecated compatibility subclass from the matching legacy path.
- `tests/Res/ResourceStorageRootTest.php`: covers canonical and legacy paths plus application delegation.
- `.github/workflows/ci.yml`: requires authoritative optimized autoload generation with strict PSR validation.

## How To Test

```powershell
composer validate --strict --no-check-lock
composer dump-autoload --classmap-authoritative --strict-psr --no-scripts
composer check-platform-reqs
vendor\bin\phpunit.bat --do-not-cache-result tests\Res\ResourceStorageRootTest.php
vendor\bin\phpunit.bat --do-not-cache-result
php examples\headless-command.php
php terminal.php --input-file=examples\batch-commands.txt --display-mode=static --output-mode=console
```

## QA Checklist

- [x] Strict authoritative autoload map generated with 4,962 classes.
- [x] Canonical and legacy reflection probes resolve distinct matching files.
- [x] Focused resource suite: 11 tests, 22 assertions.
- [x] Full suite: 220 tests, 567 assertions, three expected skips.
- [x] Headless JSON example passes.
- [x] Static batch CLI example passes.
- [x] No package dependency or runtime policy changes.

## Approval Conditions

Merge after both PHP test jobs and analysis are green, and review confirms the canonical namespace and compatibility path remain distinct under authoritative autoloading.
