### PR TITLE
Normalize separated resource identifiers

### DIFF
--- a/docs/command-parsing.md
+++ b/docs/command-parsing.md
@@ -1,0 +1,24 @@
+# Command Parsing
+
+Wise text commands use the form `<verb> <resource> [arguments]`.
+
+## Resource identifiers
+
+Unquoted resource identifiers may contain lowercase letters, digits, and single
+word separators. Hyphens are canonical. Underscores are accepted as input
+aliases and normalize to hyphens when no registered resource defines a more
+specific canonical name.
+
+Examples:
+
+- `list missing-resource` resolves the resource as `missing-resource`.
+- `list missing_resource` resolves the resource as `missing-resource`.
+- If a registered service uses `missing_resource`, either spelling resolves to
+  that registered service name so dispatch remains compatible.
+
+The first valid unquoted separated identifier after a verb is treated as the
+resource when no known resource has already been recognized. Plain unknown
+words remain arguments so native commands keep their established behavior.
+Later tokens remain arguments. Quoted values are always arguments. Structured
+command payloads are not text normalized; their resource identifiers remain
+exactly as supplied by the caller.

--- a/src/Wise/Cmd/CommandParser.php
+++ b/src/Wise/Cmd/CommandParser.php
@@ -4,6 +4,7 @@ namespace BlueFission\Wise\Cmd;
 use BlueFission\Services\Application as App;
 use BlueFission\Arr;
 use BlueFission\Str;
+use BlueFission\Val;
 
 // CommandParser.php
 class CommandParser
@@ -224,64 +225,75 @@ class CommandParser
     protected function parseResourcesAndArgs($input, Command $command)
     {
         preg_match_all('/\s*(?:(?:"([^"]*)")|([^\s"]+))/', $input, $matches, PREG_SET_ORDER);
-        $words = [];
-        $areLiterals = [];
+        $words = Arr::make();
+        $areLiterals = Arr::make();
         foreach ($matches as $match) {
-            $areLiterals[] = !isset($match[2]);
-            $words[] = isset($match[2]) ? $match[2] : $match[1];
+            $hasUnquotedValue = Val::is($match[2] ?? null);
+            $areLiterals->push(!$hasUnquotedValue);
+            $words->push($hasUnquotedValue ? $match[2] : $match[1]);
         }
 
-        $resources = [];
-        $args = [];
-        $currentArg = [];
+        $resources = Arr::make();
+        $args = Arr::make();
+        $currentArg = Arr::make();
+        $hasKnownResource = false;
 
-        $i = -1;
-        foreach ($words as $word) {
-            $i++;
-            if (in_array($word, $this->prepositions) && !$areLiterals[$i]) {
-                if ($currentArg) {
-                    $arg = implode(' ', $currentArg);
-                    $args[] = $arg;
-                    $currentArg = [];
-                }
-                continue;
+        $words->each(function ($candidate, $index) use ($areLiterals, &$hasKnownResource): void {
+            if (!$areLiterals[$index] && $this->isResource($candidate)) {
+                $hasKnownResource = true;
+            }
+        });
+
+        $flushArgument = function () use ($args, $currentArg): void {
+            if (Arr::isEmpty($currentArg->val())) {
+                return;
             }
 
-            if (in_array($word, $this->noiseWords) && !$areLiterals[$i]) {
-                if ($currentArg) {
-                    $arg = implode(' ', $currentArg);
-                    $args[] = $arg;
-                    $currentArg = [];
-                }
-                continue;
+            $args->push($currentArg->join(' ')->val());
+            $currentArg->val([]);
+        };
+
+        $words->each(function ($word, $index) use (
+            $areLiterals,
+            $resources,
+            $args,
+            $currentArg,
+            $flushArgument,
+            $hasKnownResource
+        ): void {
+            $isLiteral = (bool)$areLiterals[$index];
+            if (!$isLiteral && (
+                Arr::has($this->prepositions, $word, true)
+                || Arr::has($this->noiseWords, $word, true)
+            )) {
+                $flushArgument();
+                return;
             }
 
-            if ($this->isResource($word) && !$areLiterals[$i]) {
-                if ($currentArg) {
-                    $arg = implode(' ', $currentArg);
-                    $args[] = $arg;
-                    $currentArg = [];
-                }
-                $resources[] = $this->normalizeResource($word);
-            } elseif ($areLiterals[$i]) {
-                if ( count($currentArg) > 0) {
-                    $arg = implode(' ', $currentArg);
-                    $args[] = $arg;
-                    $currentArg = [];
-                }
-                $args[] = $word;
+            $normalizedResource = $this->normalizeResource($word);
+            if (!$isLiteral && $this->isResource($word)) {
+                $flushArgument();
+                $resources->push($normalizedResource);
+            } elseif (
+                !$isLiteral
+                && !$hasKnownResource
+                && Arr::isEmpty($resources->val())
+                && Arr::isEmpty($currentArg->val())
+                && $this->isResourceIdentifier($normalizedResource)
+            ) {
+                $resources->push($normalizedResource);
+            } elseif ($isLiteral) {
+                $flushArgument();
+                $args->push($word);
             } else {
-                $currentArg[] = $word;
+                $currentArg->push($word);
             }
-        }
+        });
 
-        if ($currentArg) {
-            $arg = implode(' ', $currentArg);
-            $args[] = $arg;
-        }
+        $flushArgument();
 
-        $command->resources = $resources;
-        $command->args = $args;
+        $command->resources = $resources->val();
+        $command->args = $args->val();
     }
 
     protected function processInput($input)
@@ -350,15 +362,15 @@ class CommandParser
     protected function isResource($word)
     {
         $word = $this->normalizeResource($word);
-        return in_array($word, $this->availableResources(), true);
+        return Arr::has($this->availableResources(), $word, true);
     }
 
     protected function normalizeResource($word)
     {
-        $word = strtolower($word);
+        $word = Str::make((string)$word)->lower()->val();
 
         // Remove noise words
-        if (in_array($word, $this->noiseWords)) {
+        if (Arr::has($this->noiseWords, $word, true)) {
             return null;
         }
 
@@ -366,9 +378,12 @@ class CommandParser
         // if (substr($word, -1) === 's' && in_array(substr($word, 0, -1), $this->knownResources)) {
         //     $word = substr($word, 0, -1);
         // }
+        $word = $this->normalizeResourceIdentifier($word);
         foreach ($this->availableResources() as $resource)
         {
-            if ($word == Str::pluralize($resource)) {
+            $canonical = $this->normalizeResourceIdentifier((string)$resource);
+            $plural = $this->normalizeResourceIdentifier(Str::pluralize((string)$resource));
+            if ($word === $canonical || $word === $plural) {
                 $word = $resource;
                 break;
             }
@@ -381,13 +396,37 @@ class CommandParser
         $word = preg_replace('/\s+/', ' ', $word); // Collapse multiple spaces
         $word = trim($word); // Trim spaces at the beginning and end
 
-        if (isset($this->quotedPlaceholders[$word])) {
+        if (Val::is($this->quotedPlaceholders[$word] ?? null)) {
             $word = $this->quotedPlaceholders[$word];
         }
 
         $word = $this->processResource($word);
 
         return $word;
+    }
+
+    protected function isResourceIdentifier(?string $word): bool
+    {
+        if (Str::isEmpty((string)$word)) {
+            return false;
+        }
+
+        return Str::make((string)$word)->matches('/^[a-z0-9]+(?:-[a-z0-9]+)+$/');
+    }
+
+    protected function normalizeResourceIdentifier(string $word): string
+    {
+        $candidate = Str::make($word)
+            ->trim()
+            ->lower()
+            ->replace('_', '-')
+            ->replacePattern('/-+/', '-')
+            ->trim('-')
+            ->val();
+
+        return Str::make($candidate)->matches('/^[a-z0-9]+(?:-[a-z0-9]+)*$/')
+            ? $candidate
+            : $word;
     }
 
     /**

--- a/tests/CommandParserTest.php
+++ b/tests/CommandParserTest.php
@@ -5,8 +5,6 @@ namespace BlueFission\Tests;
 use BlueFission\Services\Application as App;
 use BlueFission\Wise\Cmd\CommandParser;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 
 final class CommandParserTest extends TestCase
@@ -94,8 +92,6 @@ final class CommandParserTest extends TestCase
         ];
     }
 
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testSeparatedAliasResolvesRegisteredServiceName(): void
     {
         App::instance()->register('parser_test_resource', 'list', fn (): null => null);

--- a/tests/CommandParserTest.php
+++ b/tests/CommandParserTest.php
@@ -2,7 +2,11 @@
 
 namespace BlueFission\Tests;
 
+use BlueFission\Services\Application as App;
 use BlueFission\Wise\Cmd\CommandParser;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 
 final class CommandParserTest extends TestCase
@@ -64,6 +68,42 @@ final class CommandParserTest extends TestCase
         $this->assertNotNull($command);
         $this->assertSame('get', $command->verb);
         $this->assertSame(['weather'], $command->resources);
+        $this->assertSame([], $command->args);
+    }
+
+    #[DataProvider('separatedResourceIdentifiers')]
+    public function testSeparatedResourceIdentifiersNormalizeDeterministically(
+        string $input,
+        string $resource
+    ): void {
+        $parser = new CommandParser();
+
+        $first = $parser->parse($input);
+        $second = $parser->parse($input);
+
+        $this->assertSame($first->toArray(), $second->toArray());
+        $this->assertSame([$resource], $first->resources);
+        $this->assertSame([], $first->args);
+    }
+
+    public static function separatedResourceIdentifiers(): array
+    {
+        return [
+            'hyphen' => ['list missing-resource', 'missing-resource'],
+            'underscore alias' => ['list missing_resource', 'missing-resource'],
+        ];
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testSeparatedAliasResolvesRegisteredServiceName(): void
+    {
+        App::instance()->register('parser_test_resource', 'list', fn (): null => null);
+        $parser = new CommandParser();
+
+        $command = $parser->parse('list parser-test-resource');
+
+        $this->assertSame(['parser_test_resource'], $command->resources);
         $this->assertSame([], $command->args);
     }
 }

--- a/tests/CommandProcessorTest.php
+++ b/tests/CommandProcessorTest.php
@@ -28,6 +28,17 @@ final class CommandProcessorTest extends TestCase
         $this->assertSame('Resource not found', $result);
     }
 
+    public function testRepeatedSeparatedResourceIdentifierStaysComplete(): void
+    {
+        $processor = new CommandProcessor($this->makeStorage());
+
+        $first = $processor->handle('list missing-resource');
+        $second = $processor->handle('list missing-resource');
+
+        $this->assertSame('Resource not found', $first);
+        $this->assertSame('Resource not found', $second);
+    }
+
     public function testMissingResourcePromptsForResource(): void
     {
         $processor = new CommandProcessor($this->makeStorage());

--- a/tests/HeadlessCommandProcessorTest.php
+++ b/tests/HeadlessCommandProcessorTest.php
@@ -54,6 +54,17 @@ final class HeadlessCommandProcessorTest extends TestCase
         ], $result->command()?->toArray());
     }
 
+    public function testStructuredResourceIdentifierRemainsCallerDefined(): void
+    {
+        $result = $this->processor()->process(CommandRequest::parse([
+            'operator' => 'list',
+            'objects' => ['missing_resource'],
+        ]));
+
+        $this->assertSame(CommandResult::PARSED, $result->status());
+        $this->assertSame(['missing_resource'], $result->command()?->resources);
+    }
+
     public function testStructuredInputExecutesWithoutWritingToTerminal(): void
     {
         App::instance()->register('headless-resource', 'inspect', fn (): string => 'headless-output');


### PR DESCRIPTION
## Intent

Normalize separated resource identifiers in free-form command input without changing native command or structured request behavior.

## User stories and acceptance criteria

- Hyphenated identifiers such as `missing-resource` are parsed as resources.
- Underscore aliases normalize to canonical hyphenated identifiers.
- Registered service names remain authoritative when their stored spelling differs.
- Repeated parses are deterministic and do not enter an incomplete prompt loop.
- Plain unknown words remain native command arguments.
- Structured command payload identifiers remain caller-defined.

## Key files

- `src/Wise/Cmd/CommandParser.php`
- `docs/command-parsing.md`
- Parser, processor, and headless processor regression tests

## How to test

```shell
vendor/bin/phpunit --do-not-cache-result
```

Result: 225 tests, 579 assertions, 3 existing optional skips.

## QA checklist

- [x] Focused parser and routing integrations pass.
- [x] Full PHP 8.2 suite passes.
- [x] Source and test files pass PHP syntax checks.
- [x] Staged diff passes `git diff --check`.
- [x] Public parsing contract is documented.

## Approval conditions

Merge after PHP 8.2, PHP 8.3, and analysis checks pass and the exact head is confirmed.

Closes #36
