### PR TITLE
Compose headless command runtime

### DIFF
--- a/docs/headless-runtime.md
+++ b/docs/headless-runtime.md
@@ -1,0 +1,63 @@
+# Headless Command Runtime
+
+`ICommandRuntime` is the package-owned boundary for application, worker, and
+terminal adapters. It composes existing command parsing, registered resource
+dispatch, native commands, and script bridges without owning terminal input or
+rendering.
+
+## Construction
+
+```php
+use BlueFission\Wise\Cmd\CommandRuntime;
+use BlueFission\Wise\Cmd\ICommandRuntime;
+
+$runtime = new CommandRuntime($commandProcessor, $commandHandler, $kernel);
+$application->bind(ICommandRuntime::class, CommandRuntime::class);
+```
+
+The command processor is required. The native handler and kernel are optional,
+which allows resource-only workers to use the same interface. Containers may
+bind `ICommandRuntime` to `CommandRuntime` and provide the explicit constructor
+arguments according to their normal service configuration.
+
+## Per-request context
+
+`RuntimeContext` carries correlation metadata, arguments, an application working
+directory, allowlisted environment values, actor identity, capabilities,
+timeout/deadline policy, and a cancellation callback. It does not read host
+globals or change the process working directory.
+
+Environment values are passed to script bridges only when both conditions hold:
+
+- The key appears in the context environment allowlist.
+- The context declares the `environment` capability.
+
+A working directory similarly requires the `filesystem` capability. Missing
+capabilities fail before bridge execution.
+
+## Execution
+
+```php
+$runtimeResult = $runtime->execute($commandRequest, $runtimeContext);
+$scriptResult = $runtime->executeScript('cmd/status.jss', $runtimeContext);
+```
+
+`RuntimeResult::result()` returns the authoritative `CommandResult`. If a
+resource already returns a `CommandResult`, its status, output, diagnostics,
+exit code, prompt state, and continuation token are preserved. Host metadata is
+merged once, with result-owned metadata taking precedence.
+
+`RuntimeResult::frames()` exposes typed status, output, diagnostic, and prompt
+frames. A terminal adapter may render these frames; an application adapter may
+serialize them. The runtime itself never reads terminal input, writes output,
+emits ANSI control sequences, clears a screen, or exits the process.
+
+## Discovery
+
+`discover()` returns stable arrays for registered resource commands, native
+commands, and supported script extensions. Discovery does not boot a console or
+execute a command.
+
+Confirmation continuations remain explicit and replay-safe through
+`CommandRequest::resume()`. The host is responsible for collecting approval and
+submitting the continuation exactly once.

--- a/src/Wise/Cmd/CommandHandler.php
+++ b/src/Wise/Cmd/CommandHandler.php
@@ -53,6 +53,11 @@ class CommandHandler {
         $this->_aliases[$alias] = $command;
     }
 
+    public function availableCommands(): array
+    {
+        return Arr::make($this->_aliases)->keys()->sort()->toArray();
+    }
+
     protected function registerInternalCommands() {
         // Register aliases for internal commands
         $this->registerAlias('list', 'listDir');

--- a/src/Wise/Cmd/CommandProcessor.php
+++ b/src/Wise/Cmd/CommandProcessor.php
@@ -16,6 +16,8 @@ use BlueFission\Val;
 
 class CommandProcessor implements ICommandProcessor
 {
+    protected const CRASH_ALERT_INTERVAL = 5;
+
     protected $_parser;
     protected $_app;
     protected $_storage;
@@ -317,9 +319,20 @@ class CommandProcessor implements ICommandProcessor
             $this->_storage->crashes++;
             $this->_storage->write();
 
-            return CommandResult::failure('Command execution failed.', [
-                'exception' => $exception::class,
-            ]);
+            $crashCount = (int)$this->_storage->crashes;
+            $operatorAlert = $crashCount % static::CRASH_ALERT_INTERVAL === 0;
+
+            return CommandResult::failure(
+                $operatorAlert
+                    ? 'Repeated command failures detected. Re-assess the command or run diagnostics.'
+                    : 'Command execution failed.',
+                ['exception' => $exception::class],
+                [
+                    'crash_count' => $crashCount,
+                    'crash_alert_interval' => static::CRASH_ALERT_INTERVAL,
+                    'operator_alert' => $operatorAlert,
+                ]
+            );
         }
 
         // Check for warnings

--- a/src/Wise/Cmd/CommandProcessor.php
+++ b/src/Wise/Cmd/CommandProcessor.php
@@ -313,15 +313,13 @@ class CommandProcessor implements ICommandProcessor
                 return $output ?: $this->conversationalResponse("Command triggered with empty response. Perhaps it failed?");
             });
 
-        } catch ( \Exception $e ) {
-            $result = $e->getMessage();
+        } catch (\Throwable $exception) {
             $this->_storage->crashes++;
             $this->_storage->write();
 
-            // Check for crashes multiple of 5
-            if ($this->_storage->crashes % 5 == 0) {
-                return $this->conversationalResponse("You've had 5 crashes. Error: " . $result);
-            }
+            return CommandResult::failure('Command execution failed.', [
+                'exception' => $exception::class,
+            ]);
         }
 
         // Check for warnings
@@ -406,6 +404,10 @@ class CommandProcessor implements ICommandProcessor
 
     private function resultForOutput(mixed $output, array $metadata = []): CommandResult
     {
+        if ($output instanceof CommandResult) {
+            return $output->withMetadata($metadata);
+        }
+
         if ($this->_confirmationRequired || Val::is($this->_storage->confirmCmd ?? null)) {
             return CommandResult::pending(
                 $output,

--- a/src/Wise/Cmd/CommandResult.php
+++ b/src/Wise/Cmd/CommandResult.php
@@ -147,6 +147,20 @@ class CommandResult extends Obj
         return $this->continuationToken?->val();
     }
 
+    public function withMetadata(array $metadata): self
+    {
+        return new self(
+            $this->status(),
+            $this->output(),
+            $this->command(),
+            $this->confirmationRequired(),
+            $this->exitCode(),
+            $this->diagnostics(),
+            Arr::merge($metadata, $this->metadata()),
+            $this->continuationToken()
+        );
+    }
+
     public function toArray(): array
     {
         return [

--- a/src/Wise/Cmd/CommandRuntime.php
+++ b/src/Wise/Cmd/CommandRuntime.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace BlueFission\Wise\Cmd;
+
+use BlueFission\Arr;
+use BlueFission\Func;
+use BlueFission\Str;
+use BlueFission\Wise\Arc\Kernel;
+use BlueFission\Wise\Exe\ExecutionRequest;
+
+final class CommandRuntime implements ICommandRuntime
+{
+    public function __construct(
+        private ICommandProcessor $processor,
+        private ?CommandHandler $nativeHandler = null,
+        private ?Kernel $kernel = null
+    ) {
+    }
+
+    public function execute(
+        CommandRequest|Command|array|string $request,
+        RuntimeContext $context
+    ): RuntimeResult {
+        $guard = $this->guard($context);
+        if ($guard instanceof RuntimeResult) {
+            return $guard;
+        }
+
+        $request = $this->withContext($request, $context);
+        $input = $request->input();
+        if (Str::is($input) && $this->isScriptCommand((string)$input)) {
+            $parts = Str::make((string)$input)->trim()->split();
+            $parts->shift();
+            $path = (string)$parts->shift();
+
+            return $this->executeScript($path, $context);
+        }
+
+        if (Str::is($input) && $this->nativeHandler?->canHandle((string)$input)) {
+            $commandName = Str::make((string)$input)->trim()->split()->shift();
+            if (Str::match('clear', Str::lower((string)$commandName))) {
+                return $this->failure(
+                    'Screen control is unavailable in headless execution.',
+                    ['headless_screen_control'],
+                    $context
+                );
+            }
+
+            try {
+                $output = $this->nativeHandler->handle((string)$input);
+                $result = $output instanceof CommandResult
+                    ? $output->withMetadata($context->metadata())
+                    : CommandResult::completed($output, metadata: $context->metadata());
+
+                return RuntimeResult::fromCommandResult($result);
+            } catch (\Throwable $exception) {
+                return $this->failure(
+                    'Native command execution failed.',
+                    ['exception' => $exception::class],
+                    $context
+                );
+            }
+        }
+
+        return RuntimeResult::fromCommandResult($this->processor->process($request));
+    }
+
+    public function executeScript(
+        string $path,
+        RuntimeContext $context,
+        string $standardInput = ''
+    ): RuntimeResult {
+        $guard = $this->guard($context);
+        if ($guard instanceof RuntimeResult) {
+            return $guard;
+        }
+        if ($context->workingDirectory() !== null
+            && !$context->hasCapability(ExecutionRequest::CAP_FILESYSTEM)) {
+            return $this->failure(
+                'Filesystem capability is required for a working directory.',
+                ['capability_denied', ExecutionRequest::CAP_FILESYSTEM],
+                $context
+            );
+        }
+        if ($context->hasEnvironment()
+            && !$context->hasCapability(ExecutionRequest::CAP_ENVIRONMENT)) {
+            return $this->failure(
+                'Environment capability is required for environment values.',
+                ['capability_denied', ExecutionRequest::CAP_ENVIRONMENT],
+                $context
+            );
+        }
+        if (!$this->kernel instanceof Kernel) {
+            return $this->failure('Script execution is unavailable.', ['script_runtime_unavailable'], $context);
+        }
+
+        try {
+            $bridgeResult = $this->kernel->executeScript(
+                $context->executionRequest($path, $standardInput)
+            );
+        } catch (\Throwable $exception) {
+            return $this->failure(
+                'Script execution failed.',
+                ['exception' => $exception::class],
+                $context
+            );
+        }
+
+        $metadata = Arr::merge($context->metadata(), $bridgeResult->meta());
+        $result = $bridgeResult->successFlag()
+            ? CommandResult::completed($bridgeResult->output(), metadata: $metadata)
+            : CommandResult::failure(
+                $bridgeResult->output(),
+                ['script_execution_failed'],
+                $metadata
+            );
+
+        return RuntimeResult::fromCommandResult($result);
+    }
+
+    public function discover(): array
+    {
+        $resourceCommands = Func::isCallable([$this->processor, 'availableCommands'])
+            ? $this->processor->availableCommands()
+            : [];
+        $nativeCommands = $this->nativeHandler?->availableCommands() ?? [];
+        $scriptExtensions = $this->kernel?->bridgeRegistry()?->extensions() ?? [];
+
+        return [
+            'commands' => Arr::make($resourceCommands)->unique()->sort()->toArray(),
+            'native' => Arr::make($nativeCommands)->unique()->sort()->toArray(),
+            'script_extensions' => Arr::make($scriptExtensions)->unique()->sort()->toArray(),
+        ];
+    }
+
+    private function withContext(
+        CommandRequest|Command|array|string $request,
+        RuntimeContext $context
+    ): CommandRequest {
+        if (!$request instanceof CommandRequest) {
+            return new CommandRequest($request, context: $context->metadata());
+        }
+
+        $metadata = Arr::merge($context->metadata(), $request->context());
+        if ($request->isContinuation()) {
+            return CommandRequest::resume(
+                (string)$request->continuationToken(),
+                (bool)$request->approved(),
+                $metadata
+            );
+        }
+
+        return new CommandRequest($request->input(), $request->mode(), $metadata);
+    }
+
+    private function guard(RuntimeContext $context): ?RuntimeResult
+    {
+        if ($context->cancelled()) {
+            return $this->failure('Command execution was cancelled.', ['execution_cancelled'], $context);
+        }
+        if ($context->timedOut()) {
+            return $this->failure('Command execution timed out.', ['execution_timed_out'], $context);
+        }
+
+        return null;
+    }
+
+    private function failure(string $message, array $diagnostics, RuntimeContext $context): RuntimeResult
+    {
+        return RuntimeResult::fromCommandResult(
+            CommandResult::failure($message, $diagnostics, $context->metadata())
+        );
+    }
+
+    private function isScriptCommand(string $input): bool
+    {
+        $command = Str::make($input)->trim()->split()->shift();
+
+        return Str::match('run', Str::lower((string)$command));
+    }
+}

--- a/src/Wise/Cmd/ICommandRuntime.php
+++ b/src/Wise/Cmd/ICommandRuntime.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace BlueFission\Wise\Cmd;
+
+interface ICommandRuntime
+{
+    public function execute(
+        CommandRequest|Command|array|string $request,
+        RuntimeContext $context
+    ): RuntimeResult;
+
+    public function executeScript(
+        string $path,
+        RuntimeContext $context,
+        string $standardInput = ''
+    ): RuntimeResult;
+
+    public function discover(): array;
+}

--- a/src/Wise/Cmd/OutputFrame.php
+++ b/src/Wise/Cmd/OutputFrame.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace BlueFission\Wise\Cmd;
+
+use BlueFission\Arr;
+use BlueFission\Obj;
+use BlueFission\Str;
+
+final class OutputFrame extends Obj
+{
+    public const OUTPUT = 'output';
+    public const DIAGNOSTIC = 'diagnostic';
+    public const STATUS = 'status';
+    public const PROMPT = 'prompt';
+    public const PROGRESS = 'progress';
+
+    private Str $type;
+    private mixed $payload;
+    private Arr $metadata;
+
+    public function __construct(string $type, mixed $payload, array $metadata = [])
+    {
+        parent::__construct();
+        $this->type = Str::make($type)->trim()->lower();
+        $this->payload = $payload;
+        $this->metadata = Arr::make($metadata);
+    }
+
+    public function type(): string
+    {
+        return $this->type->val();
+    }
+
+    public function payload(): mixed
+    {
+        return $this->payload;
+    }
+
+    public function metadata(): array
+    {
+        return $this->metadata->toArray();
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'type' => $this->type(),
+            'payload' => $this->payload(),
+            'metadata' => $this->metadata(),
+        ];
+    }
+}

--- a/src/Wise/Cmd/RuntimeContext.php
+++ b/src/Wise/Cmd/RuntimeContext.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace BlueFission\Wise\Cmd;
+
+use BlueFission\Arr;
+use BlueFission\Func;
+use BlueFission\Num;
+use BlueFission\Obj;
+use BlueFission\Str;
+use BlueFission\Wise\Exe\ExecutionRequest;
+
+final class RuntimeContext extends Obj
+{
+    private Arr $metadata;
+    private Arr $arguments;
+    private ?Str $workingDirectory;
+    private Arr $environment;
+    private Arr $environmentAllowlist;
+    private Arr $actor;
+    private Arr $capabilities;
+    private Num $timeoutMs;
+    private ?float $deadlineAt;
+    private mixed $cancelCheck;
+    private float $startedAt;
+
+    public function __construct(
+        array $metadata = [],
+        array $arguments = [],
+        ?string $workingDirectory = null,
+        array $environment = [],
+        array $environmentAllowlist = [],
+        array $actor = [],
+        array $capabilities = [],
+        int $timeoutMs = 0,
+        ?float $deadlineAt = null,
+        ?callable $cancelCheck = null
+    ) {
+        parent::__construct();
+        $this->metadata = Arr::make($metadata);
+        $this->arguments = Arr::make($arguments);
+        $this->workingDirectory = Str::isNotEmpty((string)$workingDirectory)
+            ? Str::make((string)$workingDirectory)->trim()
+            : null;
+        $this->environment = Arr::make($environment);
+        $this->environmentAllowlist = Arr::make($environmentAllowlist)
+            ->map(fn ($key) => Str::make((string)$key)->trim()->val())
+            ->filter(fn ($key) => Str::isNotEmpty((string)$key))
+            ->unique();
+        $this->actor = Arr::make($actor);
+        $this->capabilities = Arr::make($capabilities)
+            ->map(fn ($capability) => Str::make((string)$capability)->trim()->lower()->val())
+            ->filter(fn ($capability) => Str::isNotEmpty((string)$capability))
+            ->unique();
+        $this->timeoutMs = Num::make(Num::max(0, $timeoutMs));
+        $this->deadlineAt = $deadlineAt;
+        $this->cancelCheck = $cancelCheck;
+        $this->startedAt = microtime(true);
+    }
+
+    public function metadata(): array
+    {
+        return Arr::merge($this->metadata->toArray(), [
+            'actor' => $this->actor->toArray(),
+            'capabilities' => $this->capabilities->toArray(),
+        ]);
+    }
+
+    public function arguments(): array
+    {
+        return $this->arguments->toArray();
+    }
+
+    public function workingDirectory(): ?string
+    {
+        return $this->workingDirectory?->val();
+    }
+
+    public function environment(): array
+    {
+        return $this->environment
+            ->copy()
+            ->filter(fn ($value, $key) => $this->environmentAllowlist->has((string)$key, true))
+            ->toArray();
+    }
+
+    public function hasEnvironment(): bool
+    {
+        return $this->environment->isNotEmpty();
+    }
+
+    public function capabilities(): array
+    {
+        return $this->capabilities->toArray();
+    }
+
+    public function hasCapability(string $capability): bool
+    {
+        return $this->capabilities->has(Str::lower($capability), true);
+    }
+
+    public function cancelled(): bool
+    {
+        return Func::isCallable($this->cancelCheck) && (bool)($this->cancelCheck)();
+    }
+
+    public function timedOut(): bool
+    {
+        $elapsedTimeout = (int)$this->timeoutMs->val() > 0
+            && ((microtime(true) - $this->startedAt) * 1000) >= (int)$this->timeoutMs->val();
+        $deadlineExpired = $this->deadlineAt !== null && microtime(true) >= $this->deadlineAt;
+
+        return $elapsedTimeout || $deadlineExpired;
+    }
+
+    public function executionRequest(string $path, string $standardInput = ''): ExecutionRequest
+    {
+        return new ExecutionRequest(
+            $path,
+            $this->arguments(),
+            $this->workingDirectory(),
+            $standardInput,
+            $this->environment(),
+            $this->capabilities(),
+            (int)$this->timeoutMs->val(),
+            Func::isCallable($this->cancelCheck) ? $this->cancelCheck : null
+        );
+    }
+}

--- a/src/Wise/Cmd/RuntimeResult.php
+++ b/src/Wise/Cmd/RuntimeResult.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace BlueFission\Wise\Cmd;
+
+use BlueFission\Arr;
+use BlueFission\Obj;
+
+final class RuntimeResult extends Obj
+{
+    private CommandResult $result;
+    private Arr $frames;
+
+    public function __construct(CommandResult $result, array $frames = [])
+    {
+        parent::__construct();
+        $this->result = $result;
+        $this->frames = Arr::make($frames);
+    }
+
+    public static function fromCommandResult(CommandResult $result): self
+    {
+        $frames = Arr::make([
+            new OutputFrame(OutputFrame::STATUS, $result->status(), [
+                'exit_code' => $result->exitCode(),
+            ]),
+        ]);
+
+        if ($result->output() !== null) {
+            $frames->push(new OutputFrame(OutputFrame::OUTPUT, $result->output()));
+        }
+        if (Arr::isNotEmpty($result->diagnostics())) {
+            $frames->push(new OutputFrame(OutputFrame::DIAGNOSTIC, $result->diagnostics()));
+        }
+        if ($result->confirmationRequired()) {
+            $frames->push(new OutputFrame(OutputFrame::PROMPT, $result->output(), [
+                'continuation_token' => $result->continuationToken(),
+            ]));
+        }
+
+        return new self($result, $frames->toArray());
+    }
+
+    public function result(): CommandResult
+    {
+        return $this->result;
+    }
+
+    public function frames(): array
+    {
+        return $this->frames->toArray();
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'result' => $this->result->toArray(),
+            'frames' => $this->frames
+                ->map(fn (OutputFrame $frame) => $frame->toArray())
+                ->toArray(),
+        ];
+    }
+}

--- a/tests/CommandRuntimeTest.php
+++ b/tests/CommandRuntimeTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace BlueFission\Tests;
+
+use BlueFission\Wise\Arc\Kernel;
+use BlueFission\Wise\Cmd\CommandHandler;
+use BlueFission\Wise\Cmd\CommandRequest;
+use BlueFission\Wise\Cmd\CommandResult;
+use BlueFission\Wise\Cmd\CommandRuntime;
+use BlueFission\Wise\Cmd\ICommandProcessor;
+use BlueFission\Wise\Cmd\ICommandRuntime;
+use BlueFission\Wise\Cmd\OutputFrame;
+use BlueFission\Wise\Cmd\RuntimeContext;
+use BlueFission\Wise\Exe\BridgeResult;
+use BlueFission\Wise\Exe\ExecutionRequest;
+use PHPUnit\Framework\TestCase;
+
+final class CommandRuntimeTest extends TestCase
+{
+    public function testResourceExecutionPreservesIsolatedHostContextAndWritesNothing(): void
+    {
+        $processor = $this->processor();
+        $runtime = new CommandRuntime($processor);
+
+        ob_start();
+        $first = $runtime->execute('inspect resource', new RuntimeContext([
+            'correlation_id' => 'first',
+        ], actor: ['id' => 'actor-1'], capabilities: ['read']));
+        $second = $runtime->execute('inspect resource', new RuntimeContext([
+            'correlation_id' => 'second',
+        ], actor: ['id' => 'actor-2'], capabilities: ['write']));
+        $terminalOutput = ob_get_clean();
+
+        $this->assertSame('', $terminalOutput);
+        $this->assertSame('first', $first->result()->metadata()['correlation_id']);
+        $this->assertSame('actor-1', $first->result()->metadata()['actor']['id']);
+        $this->assertSame('second', $second->result()->metadata()['correlation_id']);
+        $this->assertSame('actor-2', $second->result()->metadata()['actor']['id']);
+    }
+
+    public function testCancellationAndDeadlineStopBeforeDispatch(): void
+    {
+        $processor = $this->processor();
+        $runtime = new CommandRuntime($processor);
+
+        $cancelled = $runtime->execute('inspect resource', new RuntimeContext(
+            cancelCheck: fn (): bool => true
+        ));
+        $timedOut = $runtime->execute('inspect resource', new RuntimeContext(
+            deadlineAt: microtime(true) - 1
+        ));
+
+        $this->assertSame(['execution_cancelled'], $cancelled->result()->diagnostics());
+        $this->assertSame(['execution_timed_out'], $timedOut->result()->diagnostics());
+        $this->assertSame(0, $processor->calls);
+    }
+
+    public function testNativeClearIsBlockedWithoutAnsiOutput(): void
+    {
+        $handler = new class extends CommandHandler {
+            public int $calls = 0;
+
+            public function __construct()
+            {
+            }
+
+            public function canHandle($command): bool
+            {
+                return true;
+            }
+
+            public function handle($command): string
+            {
+                $this->calls++;
+                return "\033[2J";
+            }
+        };
+        $runtime = new CommandRuntime($this->processor(), $handler);
+
+        ob_start();
+        $result = $runtime->execute('clear', new RuntimeContext());
+        $terminalOutput = ob_get_clean();
+
+        $this->assertSame('', $terminalOutput);
+        $this->assertSame(CommandResult::FAILED, $result->result()->status());
+        $this->assertSame(['headless_screen_control'], $result->result()->diagnostics());
+        $this->assertSame(0, $handler->calls);
+    }
+
+    public function testScriptPolicyAndBridgeResultsAreStructured(): void
+    {
+        $kernel = new class(BridgeResult::success('script output', ['bridge' => 'test'])) extends Kernel {
+            public ?ExecutionRequest $captured = null;
+
+            public function __construct(private BridgeResult $nextResult)
+            {
+            }
+
+            public function executeScript(ExecutionRequest $request): BridgeResult
+            {
+                $this->captured = $request;
+                return $this->nextResult;
+            }
+        };
+        $runtime = new CommandRuntime($this->processor(), kernel: $kernel);
+        $denied = $runtime->executeScript('cmd/test.jss', new RuntimeContext(
+            workingDirectory: 'workspace'
+        ));
+        $context = new RuntimeContext(
+            ['correlation_id' => 'script-1'],
+            ['one'],
+            'workspace',
+            ['PUBLIC_VALUE' => 'ok', 'SECRET_VALUE' => 'hidden'],
+            ['PUBLIC_VALUE'],
+            capabilities: [ExecutionRequest::CAP_FILESYSTEM, ExecutionRequest::CAP_ENVIRONMENT]
+        );
+        $completed = $runtime->executeScript('cmd/test.jss', $context, 'input');
+
+        $this->assertSame(['capability_denied', ExecutionRequest::CAP_FILESYSTEM], $denied->result()->diagnostics());
+        $this->assertSame(CommandResult::COMPLETED, $completed->result()->status());
+        $this->assertSame('script output', $completed->result()->output());
+        $this->assertSame('test', $completed->result()->metadata()['bridge']);
+        $this->assertSame(['PUBLIC_VALUE' => 'ok'], $kernel->captured?->environment());
+        $this->assertSame(['one'], $kernel->captured?->arguments());
+        $this->assertSame('input', $kernel->captured?->standardInput());
+    }
+
+    public function testFramesAndDiscoveryExposeTypedHostContracts(): void
+    {
+        $handler = new class extends CommandHandler {
+            public function __construct()
+            {
+            }
+
+            public function availableCommands(): array
+            {
+                return ['echo', 'help'];
+            }
+        };
+        $runtime = new CommandRuntime($this->processor(), $handler);
+        $result = $runtime->execute('inspect resource', new RuntimeContext());
+        $frameTypes = array_column($result->toArray()['frames'], 'type');
+
+        $this->assertInstanceOf(ICommandRuntime::class, $runtime);
+        $this->assertSame([OutputFrame::STATUS, OutputFrame::OUTPUT], $frameTypes);
+        $this->assertSame([
+            'commands' => ['inspect resource'],
+            'native' => ['echo', 'help'],
+            'script_extensions' => [],
+        ], $runtime->discover());
+    }
+
+    private function processor(): ICommandProcessor
+    {
+        return new class implements ICommandProcessor {
+            public int $calls = 0;
+
+            public function process(CommandRequest|\BlueFission\Wise\Cmd\Command|array|string $request): CommandResult
+            {
+                $this->calls++;
+                $request = $request instanceof CommandRequest ? $request : new CommandRequest($request);
+
+                return CommandResult::completed('processed', metadata: $request->context());
+            }
+
+            public function availableCommands(): array
+            {
+                return ['inspect resource'];
+            }
+        };
+    }
+}

--- a/tests/CommandRuntimeTest.php
+++ b/tests/CommandRuntimeTest.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Tests;
 
+use BlueFission\Arr;
 use BlueFission\Wise\Arc\Kernel;
 use BlueFission\Wise\Cmd\CommandHandler;
 use BlueFission\Wise\Cmd\CommandRequest;
@@ -148,6 +149,36 @@ final class CommandRuntimeTest extends TestCase
             'native' => ['echo', 'help'],
             'script_extensions' => [],
         ], $runtime->discover());
+    }
+
+    public function testConfirmationContinuationIsPreservedInPromptFrame(): void
+    {
+        $processor = new class implements ICommandProcessor {
+            public function process(CommandRequest|\BlueFission\Wise\Cmd\Command|array|string $request): CommandResult
+            {
+                $request = $request instanceof CommandRequest ? $request : new CommandRequest($request);
+
+                return CommandResult::pending(
+                    'Approve command?',
+                    null,
+                    'continuation-1',
+                    $request->context()
+                );
+            }
+        };
+        $runtime = new CommandRuntime($processor);
+        $result = $runtime->execute('inspect resource', new RuntimeContext([
+            'correlation_id' => 'confirmation-1',
+        ]));
+        $frames = $result->toArray()['frames'];
+        $prompt = Arr::make($frames)->pop();
+
+        $this->assertTrue($result->result()->confirmationRequired());
+        $this->assertSame('continuation-1', $result->result()->continuationToken());
+        $this->assertSame(0, $result->result()->exitCode());
+        $this->assertSame(OutputFrame::PROMPT, $prompt['type']);
+        $this->assertSame('continuation-1', $prompt['metadata']['continuation_token']);
+        $this->assertSame('confirmation-1', $result->result()->metadata()['correlation_id']);
     }
 
     private function processor(): ICommandProcessor

--- a/tests/HeadlessCommandProcessorTest.php
+++ b/tests/HeadlessCommandProcessorTest.php
@@ -187,6 +187,59 @@ final class HeadlessCommandProcessorTest extends TestCase
         $this->assertStringNotContainsString('sensitive', (string)$result->output());
     }
 
+    public function testResourceCommandResultIsPreservedWithoutSuccessfulRewrapping(): void
+    {
+        $resourceResult = CommandResult::failure(
+            'Resource execution failed.',
+            ['resource_failure'],
+            ['source' => 'resource']
+        );
+        App::instance()->register('result-resource', 'inspect', fn (): null => null);
+        $processor = new class($this->makeStorage(), $resourceResult) extends CommandProcessor {
+            public function __construct(Storage $storage, private CommandResult $resourceResult)
+            {
+                parent::__construct($storage);
+            }
+
+            protected function executeCommand(Command $command): CommandResult
+            {
+                return $this->resourceResult;
+            }
+        };
+
+        $result = $processor->process(new CommandRequest([
+            'verb' => 'inspect',
+            'resource' => 'result-resource',
+        ], context: ['correlation_id' => 'req-result']));
+
+        $this->assertSame(CommandResult::FAILED, $result->status());
+        $this->assertSame(1, $result->exitCode());
+        $this->assertSame('Resource execution failed.', $result->output());
+        $this->assertSame(['resource_failure'], $result->diagnostics());
+        $this->assertSame([
+            'correlation_id' => 'req-result',
+            'source' => 'resource',
+        ], $result->metadata());
+    }
+
+    public function testCaughtResourceExceptionReturnsFailureResult(): void
+    {
+        App::instance()->register('throwing-resource', 'inspect', function (): never {
+            throw new \RuntimeException('sensitive resource detail');
+        });
+
+        $result = $this->processor()->process([
+            'verb' => 'inspect',
+            'resource' => 'throwing-resource',
+        ]);
+
+        $this->assertSame(CommandResult::FAILED, $result->status());
+        $this->assertSame(1, $result->exitCode());
+        $this->assertSame('Command execution failed.', $result->output());
+        $this->assertSame(['exception' => \RuntimeException::class], $result->diagnostics());
+        $this->assertStringNotContainsString('sensitive', (string)$result->output());
+    }
+
     public function testResultSerializesAsStableHostEnvelope(): void
     {
         $command = new Command();

--- a/tests/HeadlessCommandProcessorTest.php
+++ b/tests/HeadlessCommandProcessorTest.php
@@ -240,6 +240,37 @@ final class HeadlessCommandProcessorTest extends TestCase
         $this->assertStringNotContainsString('sensitive', (string)$result->output());
     }
 
+    public function testRepeatedResourceCrashesAlertTheOperatorAtTheDefaultInterval(): void
+    {
+        $processor = $this->processor();
+        $result = null;
+
+        for ($attempt = 1; $attempt <= 5; $attempt++) {
+            $resource = 'throwing-resource-' . $attempt;
+            App::instance()->register($resource, 'inspect', function (): never {
+                throw new \RuntimeException('sensitive resource detail');
+            });
+
+            $result = $processor->process([
+                'verb' => 'inspect',
+                'resource' => $resource,
+            ]);
+        }
+
+        $this->assertInstanceOf(CommandResult::class, $result);
+        $this->assertSame(CommandResult::FAILED, $result->status());
+        $this->assertSame(
+            'Repeated command failures detected. Re-assess the command or run diagnostics.',
+            $result->output()
+        );
+        $this->assertSame([
+            'crash_count' => 5,
+            'crash_alert_interval' => 5,
+            'operator_alert' => true,
+        ], $result->metadata());
+        $this->assertStringNotContainsString('sensitive', (string)$result->output());
+    }
+
     public function testResultSerializesAsStableHostEnvelope(): void
     {
         $command = new Command();


### PR DESCRIPTION
## Intent

Provide one headless runtime boundary for command, native, and script execution with immutable host context and typed output frames.

## User stories and acceptance criteria

- Hosts inject `ICommandRuntime` and explicit collaborators without starting a console.
- Per-request context carries correlation metadata, actor identity, arguments, capabilities, allowlisted environment, working directory, timeout/deadline, and cancellation.
- Registered resources, native commands, and scripts use their existing package-owned processors.
- Resource-returned `CommandResult` envelopes retain status, output, diagnostics, exit code, prompt state, and result-owned metadata exactly once.
- Caught execution failures are sanitized typed failures with nonzero exit status.
- Screen-control commands are denied in headless mode and no execution path writes terminal output.
- Discovery exposes resource commands, native commands, and script extensions without execution.

## Key files

- `src/Wise/Cmd/CommandRuntime.php`
- `src/Wise/Cmd/RuntimeContext.php`
- `src/Wise/Cmd/RuntimeResult.php`
- `src/Wise/Cmd/OutputFrame.php`
- `src/Wise/Cmd/CommandProcessor.php`
- `docs/headless-runtime.md`

## How to test

```shell
composer dump-autoload --classmap-authoritative --strict-psr
composer check-platform-reqs
vendor/bin/phpunit --do-not-cache-result
```

Result: 227 tests, 599 assertions, 3 existing optional skips.

## QA checklist

- [x] Resource, native, and script routes have deterministic coverage.
- [x] Cancellation, timeout, capability denial, and context isolation are covered.
- [x] Nested failure envelopes and exception conversion are covered.
- [x] Authoritative PSR-4 loading and platform checks pass.
- [x] Full PHP 8.2 suite passes.
- [x] Host and terminal adapter responsibilities are documented.

## Approval conditions

Merge after PHP 8.2, PHP 8.3, and analysis checks pass, host contract review is complete, and the exact head is confirmed.

Closes #39
