### PR TITLE
Complete optional authentication provider lifecycle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,9 @@
         "phpunit/phpunit": "^11.1@dev",
         "php": ">=8.0.0"
     },
+    "suggest": {
+        "bluefission/presence": "Enables advanced authentication, authorization, and session integration."
+    },
     "autoload": {
         "psr-4": {
             "BlueFission\\": [

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,71 @@
+# Authentication Providers
+
+Wise owns `AuthProviderInterface` as its authentication boundary. The default
+kernel behavior remains the built-in DevElation authenticator. An application
+may inject another provider as the final `Kernel` constructor argument without
+changing command or terminal code.
+
+## Presence provider
+
+`PresenceAuthProvider` adapts a configured Presence authenticator registry to
+Wise profiles. Presence remains optional so clean CLI and headless installations
+do not require authentication infrastructure.
+
+The host must provide a registry with the authenticators required by its policy:
+
+```php
+use BlueFission\Presence\Auth\AuthenticatorRegistry;
+use BlueFission\Wise\Usr\Auth\PresenceAuthProvider;
+
+$registry = new AuthenticatorRegistry();
+$registry->register($configuredAuthenticator);
+
+$provider = new PresenceAuthProvider(
+    $registry,
+    logoutHandler: $revokeSession
+);
+
+$kernel = new Kernel(
+    $processManager,
+    $commandProcessor,
+    $memoryManager,
+    $fileSystemManager,
+    $interpreter,
+    $console,
+    $sessionStorage,
+    $dataStorage,
+    $ipc,
+    $provider
+);
+```
+
+The default credential and context factories map identifier, secret, credential
+type, request metadata, session id, and tenant id to Presence value objects.
+Custom factories may be injected for other credential or context policies.
+
+Successful principals map their id, roles, and permissions into a Wise
+`Profile`. Authentication reasons and non-secret metadata are preserved.
+Credentials and secrets are never added to the outcome metadata.
+
+## Logout and sessions
+
+Presence authentication registries do not own host session revocation. Supply a
+logout handler that revokes the authenticated session through the host's session
+service. The handler receives the last successful `AuthOutcome`.
+
+Wise always clears local provider identity in a `finally` block. A revocation
+exception is propagated after local cleanup so the caller can report that the
+remote session may still exist. Without a logout handler, logout remains local.
+
+## Failure behavior
+
+- Missing Presence classes or an unconfigured registry produce an unavailable
+  or unsupported-provider outcome; the legacy authenticator remains available
+  when no provider is injected.
+- Authentication exceptions are normalized to
+  `presence_authentication_failed` without exposing credential values.
+- Missing principals, rejected credentials, role mapping, permission checks,
+  local logout, and revocation failure have deterministic test coverage.
+
+No provider credentials belong in source control. Construct authenticators and
+session services from the host's secret/configuration system and inject them.

--- a/src/Wise/Arc/Kernel.php
+++ b/src/Wise/Arc/Kernel.php
@@ -22,6 +22,7 @@ use BlueFission\Arr;
 use BlueFission\Str;
 use BlueFission\Val;
 use BlueFission\Wise\Usr\Profile;
+use BlueFission\Wise\Usr\Auth\AuthProviderInterface;
 use BlueFission\Wise\Sys\Memory\WorkingMemoryCoordinator;
 use BlueFission\Wise\Exe\{BridgeRegistry, BridgeContext, BridgeResult, ExecutionRequest};
 use BlueFission\Wise\Res\ScriptedResourceRegistry;
@@ -58,7 +59,7 @@ class Kernel {
 
     const INPUT_CHANNEL = '__input__';
 
-    public function __construct(ProcessManager $processManager, CommandProcessor $commandProcessor, MemoryManager $memoryManager, FileSystemManager $fileSystemManager, IInterpreter $interpreter, Console $console, Storage $sessionStorage, Storage $dataStorage, IPC $ipc) {
+    public function __construct(ProcessManager $processManager, CommandProcessor $commandProcessor, MemoryManager $memoryManager, FileSystemManager $fileSystemManager, IInterpreter $interpreter, Console $console, Storage $sessionStorage, Storage $dataStorage, IPC $ipc, ?AuthProviderInterface $authProvider = null) {
         if (self::$_instance) {
             return self::$_instance;
         }
@@ -76,7 +77,11 @@ class Kernel {
         $this->_output = '';
 
         $this->_commandHandler = new CommandHandler($this);
-        $this->_identity = new Identity($this, new Auth( $this->_sessionStorage, $this->_dataStorage ));
+        $this->_identity = new Identity(
+            $this,
+            new Auth($this->_sessionStorage, $this->_dataStorage),
+            $authProvider
+        );
         $this->_profile = $this->_identity->profile();
         $this->_systemProfile = new Profile('system', ['system']);
 

--- a/src/Wise/Usr/Auth/PresenceAuthProvider.php
+++ b/src/Wise/Usr/Auth/PresenceAuthProvider.php
@@ -18,23 +18,26 @@ class PresenceAuthProvider extends Obj implements AuthProviderInterface
     private ?object $registry;
     private $credentialFactory;
     private $contextFactory;
+    private $logoutHandler;
     private ?AuthOutcome $outcome = null;
 
     public function __construct(
         ?object $registry = null,
         ?callable $credentialFactory = null,
-        ?callable $contextFactory = null
+        ?callable $contextFactory = null,
+        ?callable $logoutHandler = null
     ) {
         parent::__construct();
         $this->registry = $registry ?? $this->defaultRegistry();
         $this->credentialFactory = $credentialFactory ?? $this->defaultCredentialFactory();
         $this->contextFactory = $contextFactory ?? $this->defaultContextFactory();
+        $this->logoutHandler = $logoutHandler;
     }
 
     public function available(): bool
     {
         return Val::is($this->registry)
-            && method_exists($this->registry, 'authenticate')
+            && Func::isCallable([$this->registry, 'authenticate'])
             && Func::isCallable($this->credentialFactory)
             && Func::isCallable($this->contextFactory);
     }
@@ -55,7 +58,9 @@ class PresenceAuthProvider extends Obj implements AuthProviderInterface
             ]);
         }
 
-        if (!is_object($result) || !method_exists($result, 'isSuccessful') || !$result->isSuccessful()) {
+        if (!Val::make($result)->check('is_object')
+            || !Func::isCallable([$result, 'isSuccessful'])
+            || !$result->isSuccessful()) {
             return $this->outcome = AuthOutcome::failure(
                 (string)($result->reason ?? 'authentication_failed'),
                 Arr::is($result->metadata ?? null) ? $result->metadata : []
@@ -63,14 +68,14 @@ class PresenceAuthProvider extends Obj implements AuthProviderInterface
         }
 
         $principal = $result->principal ?? null;
-        if (!is_object($principal) || !method_exists($principal, 'id')) {
+        if (!Val::make($principal)->check('is_object') || !Func::isCallable([$principal, 'id'])) {
             return $this->outcome = AuthOutcome::failure('presence_principal_missing');
         }
 
         $profile = new Profile(
             (string)$principal->id(),
-            $this->namesFromCollection(method_exists($principal, 'roles') ? $principal->roles() : null, ['user']),
-            $this->namesFromCollection(method_exists($principal, 'permissions') ? $principal->permissions() : null)
+            $this->namesFromCollection(Func::isCallable([$principal, 'roles']) ? $principal->roles() : null, ['user']),
+            $this->namesFromCollection(Func::isCallable([$principal, 'permissions']) ? $principal->permissions() : null)
         );
 
         return $this->outcome = AuthOutcome::success($profile, Arr::merge(
@@ -81,7 +86,13 @@ class PresenceAuthProvider extends Obj implements AuthProviderInterface
 
     public function logout(): void
     {
-        $this->outcome = null;
+        try {
+            if (Func::isCallable($this->logoutHandler) && Val::is($this->outcome)) {
+                ($this->logoutHandler)($this->outcome);
+            }
+        } finally {
+            $this->outcome = null;
+        }
     }
 
     public function isAuthenticated(): bool
@@ -145,7 +156,7 @@ class PresenceAuthProvider extends Obj implements AuthProviderInterface
 
     private function namesFromCollection(mixed $collection, array $default = []): array
     {
-        if (is_object($collection) && method_exists($collection, 'toArray')) {
+        if (Val::make($collection)->check('is_object') && Func::isCallable([$collection, 'toArray'])) {
             $collection = $collection->toArray(true);
         }
         if (!Arr::is($collection)) {

--- a/tests/AuthProviderTest.php
+++ b/tests/AuthProviderTest.php
@@ -107,6 +107,63 @@ final class AuthProviderTest extends TestCase
         $this->assertSame('guest', $identity->profile()->id());
     }
 
+    public function testPresenceLogoutInvokesRevocationAndClearsLocalIdentity(): void
+    {
+        $revokedProfile = null;
+        $registry = new FakePresenceRegistry(FakePresenceResult::success(
+            new FakePresencePrincipal(
+                'user-42',
+                new FakePresenceCollection(['operator']),
+                new FakePresenceCollection(['resource.read'])
+            )
+        ));
+        $provider = new PresenceAuthProvider(
+            $registry,
+            static fn (AuthRequest $request): object => (object)['secret' => $request->secret()],
+            static fn (): object => (object)[],
+            static function ($outcome) use (&$revokedProfile): void {
+                $revokedProfile = $outcome->profile()?->id();
+            }
+        );
+        $provider->authenticate(new AuthRequest('alex', 'secret'));
+
+        $provider->logout();
+
+        $this->assertSame('user-42', $revokedProfile);
+        $this->assertFalse($provider->isAuthenticated());
+        $this->assertNull($provider->profile());
+    }
+
+    public function testPresenceLogoutFailsClosedWhenRevocationFails(): void
+    {
+        $registry = new FakePresenceRegistry(FakePresenceResult::success(
+            new FakePresencePrincipal(
+                'user-42',
+                new FakePresenceCollection(['operator']),
+                new FakePresenceCollection([])
+            )
+        ));
+        $provider = new PresenceAuthProvider(
+            $registry,
+            static fn (AuthRequest $request): object => (object)['secret' => $request->secret()],
+            static fn (): object => (object)[],
+            static function (): never {
+                throw new \RuntimeException('revocation unavailable');
+            }
+        );
+        $provider->authenticate(new AuthRequest('alex', 'secret'));
+
+        try {
+            $provider->logout();
+            $this->fail('Expected the revocation failure to be propagated.');
+        } catch (\RuntimeException $exception) {
+            $this->assertSame('revocation unavailable', $exception->getMessage());
+        }
+
+        $this->assertFalse($provider->isAuthenticated());
+        $this->assertNull($provider->profile());
+    }
+
     private function makeProvider(FakePresenceRegistry $registry): PresenceAuthProvider
     {
         return new PresenceAuthProvider(


### PR DESCRIPTION
## Intent

Complete the package-owned optional authentication integration and lifecycle needed for an installed, configured Presence provider.

## User stories and acceptance criteria

- Kernel construction accepts any `AuthProviderInterface` while retaining the legacy default.
- A configured Presence registry maps authenticated principals to Wise profile ids, roles, and permissions.
- Provider absence and authentication failures remain deterministic and secret-safe.
- Hosts may inject session revocation without coupling Wise to one session backend.
- Logout always clears local identity, and remote revocation failures are propagated after cleanup.
- Composer advertises the optional package without making clean CLI or headless installs depend on it.
- Setup, configuration, failure behavior, and secret handling are documented.

## Key files

- `src/Wise/Usr/Auth/PresenceAuthProvider.php`
- `src/Wise/Arc/Kernel.php`
- `docs/authentication.md`
- `composer.json`
- `tests/AuthProviderTest.php`

## How to test

```shell
composer dump-autoload --classmap-authoritative --strict-psr
composer check-platform-reqs
vendor/bin/phpunit --do-not-cache-result
```

Result: 222 tests, 573 assertions, 3 existing optional skips.

## QA checklist

- [x] Success, rejection, exception, provider fallback, role, and permission paths pass.
- [x] Local logout, revocation callback, and fail-closed revocation failure pass.
- [x] Authoritative PSR-4 loading and platform checks pass.
- [x] Full PHP 8.2 suite passes.
- [x] No credentials or secret values are committed or exposed in outcomes.

## Approval conditions

Merge after PHP 8.2, PHP 8.3, and analysis checks pass and the exact head is confirmed. Issue #17 should close only after the optional upstream package has a reviewed Packagist release and a clean consumer install verifies the default factories; that publication remains tracked upstream.
