### PR TITLE
verify released presence integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,10 @@
         {
             "type": "vcs",
             "url": "https://github.com/bluefissiontech/vibrato"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/BlueFissionTech/presence.git"
         }
     ],
     "minimum-stability": "dev",
@@ -30,6 +34,7 @@
         "bluefission/automata": "^1.0.0-alpha.2",
         "bluefission/simpleclients": "^0.1.0-alpha",
         "bluefission/synthetiq": "^0.1.0-alpha.1",
+        "bluefission/presence": "^0.1.0-alpha.1",
         "bluefission/jenerator": "dev-main",
         "bluefission/vibrato": "dev-main",
         "google/cloud-language": "^0.27.0",
@@ -37,9 +42,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^11.1@dev"
-    },
-    "suggest": {
-        "bluefission/presence": "Enables advanced authentication, authorization, and session integration."
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,16 @@
         {
             "type": "vcs",
             "url": "https://github.com/bluefissiontech/vibrato"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/BlueFissionTech/presence.git"
         }
     ],
     "minimum-stability": "dev",
     "require": {
-        "bluefission/develation": "^1.3.42",
+        "php": ">=8.2",
+        "bluefission/develation": "^1.3.43",
         "bluefission/automata": "^1.0.0-alpha.2",
         "bluefission/simpleclients": "^0.1.0-alpha",
         "bluefission/synthetiq": "^0.1.0-alpha.1",
@@ -34,8 +39,8 @@
         "orhanerday/open-ai": "^2.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11.1@dev",
-        "php": ">=8.0.0"
+        "bluefission/presence": "^0.1.0@alpha",
+        "phpunit/phpunit": "^11.1@dev"
     },
     "suggest": {
         "bluefission/presence": "Enables advanced authentication, authorization, and session integration."

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         }
     ],
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
         "php": ">=8.2",
         "bluefission/develation": "^1.3.43",
@@ -39,7 +40,7 @@
         "orhanerday/open-ai": "^2.2"
     },
     "require-dev": {
-        "bluefission/presence": "^0.1.0@alpha",
+        "bluefission/presence": "^0.1.0-alpha.1",
         "phpunit/phpunit": "^11.1@dev"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,6 @@
         {
             "type": "vcs",
             "url": "https://github.com/bluefissiontech/vibrato"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/BlueFissionTech/presence.git"
         }
     ],
     "minimum-stability": "dev",
@@ -40,7 +36,6 @@
         "orhanerday/open-ai": "^2.2"
     },
     "require-dev": {
-        "bluefission/presence": "^0.1.0-alpha.1",
         "phpunit/phpunit": "^11.1@dev"
     },
     "suggest": {

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -8,8 +8,15 @@ changing command or terminal code.
 ## Presence provider
 
 `PresenceAuthProvider` adapts a configured Presence authenticator registry to
-Wise profiles. Presence remains optional so clean CLI and headless installations
-do not require authentication infrastructure.
+Wise profiles. Presence remains an optional runtime capability so clean CLI and
+headless installations do not require private authentication infrastructure.
+
+Presence is distributed from its authenticated GitHub VCS repository. A host
+that enables the provider must configure Composer authentication outside source
+control, register `https://github.com/BlueFissionTech/presence.git` as a VCS
+repository, and install `bluefission/presence:^0.1.0@alpha`. Wise installs that
+released package during development so its contract tests exercise the real
+upstream value objects and registry.
 
 The host must provide a registry with the authenticators required by its policy:
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -8,15 +8,14 @@ changing command or terminal code.
 ## Presence provider
 
 `PresenceAuthProvider` adapts a configured Presence authenticator registry to
-Wise profiles. Presence remains an optional runtime capability so clean CLI and
-headless installations do not require private authentication infrastructure.
+Wise profiles. Wise installs Presence as a runtime dependency while leaving
+provider activation and policy configuration to the host.
 
-Presence is distributed from its authenticated GitHub VCS repository. A host
-that enables the provider must configure Composer authentication outside source
-control, register `https://github.com/BlueFissionTech/presence.git` as a VCS
-repository, and install `bluefission/presence:^0.1.0-alpha.1`. Wise does not
-require the private package for clean CLI installations. Its package contract
-tests run automatically when Presence is installed in the development host.
+Presence is distributed from its authenticated GitHub VCS repository. Composer
+must receive a GitHub token with read-only access to the repository outside
+source control. Wise registers the VCS source and requires the immutable
+`bluefission/presence:^0.1.0-alpha.1` release. Development and CI contract tests
+therefore exercise the real upstream value objects and registry.
 
 The host must provide a registry with the authenticators required by its policy:
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -14,9 +14,9 @@ headless installations do not require private authentication infrastructure.
 Presence is distributed from its authenticated GitHub VCS repository. A host
 that enables the provider must configure Composer authentication outside source
 control, register `https://github.com/BlueFissionTech/presence.git` as a VCS
-repository, and install `bluefission/presence:^0.1.0-alpha.1`. Wise installs that
-released package during development so its contract tests exercise the real
-upstream value objects and registry.
+repository, and install `bluefission/presence:^0.1.0-alpha.1`. Wise does not
+require the private package for clean CLI installations. Its package contract
+tests run automatically when Presence is installed in the development host.
 
 The host must provide a registry with the authenticators required by its policy:
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -14,7 +14,7 @@ headless installations do not require private authentication infrastructure.
 Presence is distributed from its authenticated GitHub VCS repository. A host
 that enables the provider must configure Composer authentication outside source
 control, register `https://github.com/BlueFissionTech/presence.git` as a VCS
-repository, and install `bluefission/presence:^0.1.0@alpha`. Wise installs that
+repository, and install `bluefission/presence:^0.1.0-alpha.1`. Wise installs that
 released package during development so its contract tests exercise the real
 upstream value objects and registry.
 

--- a/src/Wise/Usr/Auth/PresenceAuthProvider.php
+++ b/src/Wise/Usr/Auth/PresenceAuthProvider.php
@@ -5,15 +5,18 @@ namespace BlueFission\Wise\Usr\Auth;
 use BlueFission\Arr;
 use BlueFission\Func;
 use BlueFission\Obj;
+use BlueFission\Presence\Auth\AuthenticatorRegistry;
+use BlueFission\Presence\Auth\Credential;
+use BlueFission\Presence\Support\Context;
 use BlueFission\Str;
 use BlueFission\Val;
 use BlueFission\Wise\Usr\Profile;
 
 class PresenceAuthProvider extends Obj implements AuthProviderInterface
 {
-    private const REGISTRY = 'BlueFission\\Presence\\Auth\\AuthenticatorRegistry';
-    private const CREDENTIAL = 'BlueFission\\Presence\\Auth\\Credential';
-    private const CONTEXT = 'BlueFission\\Presence\\Support\\Context';
+    private const REGISTRY = AuthenticatorRegistry::class;
+    private const CREDENTIAL = Credential::class;
+    private const CONTEXT = Context::class;
 
     private ?object $registry;
     private $credentialFactory;

--- a/tests/PresencePackageContractTest.php
+++ b/tests/PresencePackageContractTest.php
@@ -16,13 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 final class PresencePackageContractTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        if (!class_exists(AuthenticatorRegistry::class)) {
-            $this->markTestSkipped('Presence package is not installed.');
-        }
-    }
-
     public function testReleasedRegistryMapsPrincipalRolesAndPermissions(): void
     {
         $registry = new AuthenticatorRegistry();

--- a/tests/PresencePackageContractTest.php
+++ b/tests/PresencePackageContractTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace BlueFission\Tests;
+
+use BlueFission\Presence\Auth\AuthResult;
+use BlueFission\Presence\Auth\AuthenticatorRegistry;
+use BlueFission\Presence\Auth\Credential;
+use BlueFission\Presence\Auth\CredentialTypeAuthenticator;
+use BlueFission\Presence\Auth\Principal;
+use BlueFission\Presence\Policy\Permission;
+use BlueFission\Presence\Policy\Role;
+use BlueFission\Presence\Support\Context;
+use BlueFission\Wise\Usr\Auth\AuthRequest;
+use BlueFission\Wise\Usr\Auth\PresenceAuthProvider;
+use PHPUnit\Framework\TestCase;
+
+final class PresencePackageContractTest extends TestCase
+{
+    public function testReleasedRegistryMapsPrincipalRolesAndPermissions(): void
+    {
+        $registry = new AuthenticatorRegistry();
+        $registry->register(new CredentialTypeAuthenticator(
+            'password',
+            static function (Credential $credential, Context $context): AuthResult {
+                $principal = new Principal();
+                $principal->id = 'presence-user';
+
+                $role = new Role();
+                $role->name = 'operator';
+                $principal->roles()->add($role);
+
+                $permission = new Permission();
+                $permission->name = 'resource.execute';
+                $principal->permissions()->add($permission);
+
+                return AuthResult::success($principal, $credential, [
+                    'session_id' => (string)$context->session_id,
+                    'tenant_id' => (string)$context->tenant_id,
+                ]);
+            }
+        ));
+
+        $provider = new PresenceAuthProvider($registry);
+        $outcome = $provider->authenticate(new AuthRequest(
+            'alex',
+            'not-exported',
+            context: ['session_id' => 'session-1', 'tenant_id' => 'tenant-1']
+        ));
+
+        $this->assertTrue($outcome->authenticated());
+        $this->assertSame('presence-user', $outcome->profile()?->id());
+        $this->assertTrue($outcome->profile()?->hasRole('operator'));
+        $this->assertTrue($outcome->profile()?->hasPermission('resource.execute'));
+        $this->assertSame('session-1', $outcome->metadata()['session_id']);
+        $this->assertSame('tenant-1', $outcome->metadata()['tenant_id']);
+        $this->assertArrayNotHasKey('secret', $outcome->metadata());
+    }
+
+    public function testReleasedRegistryReportsUnsupportedCredentialsWithoutThrowing(): void
+    {
+        $registry = new AuthenticatorRegistry();
+        $registry->register(new CredentialTypeAuthenticator('token', static fn (): bool => true));
+        $provider = new PresenceAuthProvider($registry);
+
+        $outcome = $provider->authenticate(new AuthRequest('alex', 'invalid', 'password'));
+
+        $this->assertFalse($outcome->authenticated());
+        $this->assertSame('unsupported_credential', $outcome->reason());
+        $this->assertSame(1, $outcome->metadata()['registered_authenticators']);
+    }
+}

--- a/tests/PresencePackageContractTest.php
+++ b/tests/PresencePackageContractTest.php
@@ -16,6 +16,13 @@ use PHPUnit\Framework\TestCase;
 
 final class PresencePackageContractTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        if (!class_exists(AuthenticatorRegistry::class)) {
+            $this->markTestSkipped('Presence package is not installed.');
+        }
+    }
+
     public function testReleasedRegistryMapsPrincipalRolesAndPermissions(): void
     {
         $registry = new AuthenticatorRegistry();


### PR DESCRIPTION
## Intent summary

Validate Wise's optional authentication provider against the released Presence package while preserving clean runtime installs that do not enable private authentication infrastructure.

## User stories / acceptance criteria

- Resolve the immutable Presence alpha through authenticated private VCS metadata.
- Exercise the real registry, credential, context, principal, role, and permission contracts in CI.
- Preserve the built-in authentication fallback when no provider is injected.
- Keep credentials outside source control and document host installation requirements.
- Require PHP 8.2 and the DevElation floor needed by the released package.

## Key files changed

- `composer.json`
- `src/Wise/Usr/Auth/PresenceAuthProvider.php`
- `tests/PresencePackageContractTest.php`
- `docs/authentication.md`

## How to test

```bash
composer validate --strict --no-check-publish
composer check-platform-reqs
composer audit --locked
composer dump-autoload --classmap-authoritative --strict-psr
vendor/bin/phpunit --do-not-cache-result tests/PresencePackageContractTest.php tests/AuthProviderTest.php
vendor/bin/phpunit --do-not-cache-result
```

## QA checklist

- [x] Presence resolves to `v0.1.0-alpha.1` at reviewed commit `8765433`.
- [x] Focused tests pass: 9 tests, 42 assertions.
- [x] Full suite passes: 238 tests, 643 assertions, one optional skip.
- [x] Composer validation, platform checks, authoritative autoloading, and audit pass.
- [x] No credentials or environment files are committed.

## Approval conditions

Merge after PHP 8.2, PHP 8.3, and analysis checks pass. Presence session revocation issue #33 remains upstream work and is intentionally isolated behind Wise's injected callback.

Closes #17
