### PR TITLE
publish authoritative resource catalog

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,0 +1,21 @@
+# Resource Catalog
+
+`ResourceCatalog` is the authoritative package contract for resource class
+discovery. Hosts should consume `definitions()` or `describe()` instead of
+constructing class names from resource identifiers.
+
+Canonical system and command capabilities resolve to `SystemResource` and
+`CommandResource`. The website capability resolves to the PSR-4-aligned
+`WebBrowserResource`. Legitimate command aliases such as `web` and
+`filemanager` resolve through `aliases()` while preserving one canonical class
+entry.
+
+Message, transcript, and generic resource-management capabilities currently
+have no package-owned PHP resource class. They are returned as `unavailable`
+with the `not_implemented` reason. Required hosts should report that status;
+optional hosts may omit the capability atomically. They must not construct or
+register compatibility classes for those identifiers.
+
+`missingClasses()` validates that every available catalog entry is loadable.
+The CI authoritative Composer autoload step and resource catalog tests enforce
+the class/file contract on PHP 8.2 and 8.3.

--- a/src/Wise/Res/ResourceCatalog.php
+++ b/src/Wise/Res/ResourceCatalog.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace BlueFission\Wise\Res;
+
+use BlueFission\Arr;
+use BlueFission\Obj;
+use BlueFission\Str;
+
+class ResourceCatalog extends Obj
+{
+    public const AVAILABLE = 'available';
+    public const UNAVAILABLE = 'unavailable';
+    public const UNKNOWN = 'unknown';
+
+    private const RESOURCES = [
+        'action' => ActionResource::class,
+        'ai' => AIResource::class,
+        'api' => APIResource::class,
+        'calc' => CalculatorResource::class,
+        'command' => CommandResource::class,
+        'entity' => EntityResource::class,
+        'feature' => FeatureResource::class,
+        'file' => FileResource::class,
+        'howto' => HowToResource::class,
+        'info' => EncyclopediaResource::class,
+        'news' => NewsResource::class,
+        'note' => NoteResource::class,
+        'queue' => QueueResource::class,
+        'schedule' => ScheduleResource::class,
+        'search' => SearchResource::class,
+        'stack' => StackResource::class,
+        'step' => StepResource::class,
+        'system' => SystemResource::class,
+        'todo' => TodoResource::class,
+        'variable' => VariableResource::class,
+        'weather' => WeatherResource::class,
+        'website' => WebBrowserResource::class,
+    ];
+
+    private const ALIASES = [
+        'calculator' => 'calc',
+        'encyclopedia' => 'info',
+        'filemanager' => 'file',
+        'web' => 'website',
+    ];
+
+    private const UNAVAILABLE_RESOURCES = [
+        'message' => 'not_implemented',
+        'resource' => 'not_implemented',
+        'transcript' => 'not_implemented',
+    ];
+
+    private Arr $resources;
+    private Arr $aliases;
+    private Arr $unavailableResources;
+
+    public function __construct(
+        array $resources = [],
+        array $aliases = [],
+        array $unavailableResources = []
+    ) {
+        parent::__construct();
+        $this->resources = Arr::make($this->normalizeMap(Arr::merge(self::RESOURCES, $resources)));
+        $this->aliases = Arr::make($this->normalizeMap(Arr::merge(self::ALIASES, $aliases), true));
+        $this->unavailableResources = Arr::make($this->normalizeMap(Arr::merge(
+            self::UNAVAILABLE_RESOURCES,
+            $unavailableResources
+        )));
+    }
+
+    public function definitions(): array
+    {
+        return $this->resources->toArray();
+    }
+
+    public function aliases(): array
+    {
+        return $this->aliases->toArray();
+    }
+
+    public function unavailable(): array
+    {
+        return $this->unavailableResources->toArray();
+    }
+
+    public function identifiers(bool $includeUnavailable = false): array
+    {
+        $identifiers = Arr::keys($this->definitions());
+        if ($includeUnavailable) {
+            $identifiers = Arr::merge($identifiers, Arr::keys($this->unavailable()));
+        }
+
+        return Arr::make($identifiers)->unique()->sort()->toArray();
+    }
+
+    public function classFor(string $identifier): ?string
+    {
+        $identifier = $this->canonicalIdentifier($identifier);
+        $definitions = $this->definitions();
+
+        return Arr::hasKey($definitions, $identifier) ? $definitions[$identifier] : null;
+    }
+
+    public function status(string $identifier): string
+    {
+        $identifier = $this->canonicalIdentifier($identifier);
+        if (Arr::hasKey($this->definitions(), $identifier)) {
+            return self::AVAILABLE;
+        }
+        if (Arr::hasKey($this->unavailable(), $identifier)) {
+            return self::UNAVAILABLE;
+        }
+
+        return self::UNKNOWN;
+    }
+
+    public function describe(string $identifier): array
+    {
+        $requested = $this->normalize($identifier);
+        $canonical = $this->canonicalIdentifier($requested);
+        $status = $this->status($canonical);
+        $unavailable = $this->unavailable();
+
+        return [
+            'identifier' => $requested,
+            'canonical_identifier' => $canonical,
+            'status' => $status,
+            'class' => $status === self::AVAILABLE ? $this->classFor($canonical) : null,
+            'reason' => $status === self::UNAVAILABLE ? $unavailable[$canonical] : null,
+        ];
+    }
+
+    public function missingClasses(): array
+    {
+        $missing = Arr::make();
+        foreach ($this->definitions() as $identifier => $class) {
+            if (!class_exists($class)) {
+                $missing[$identifier] = $class;
+            }
+        }
+
+        return $missing->toArray();
+    }
+
+    private function canonicalIdentifier(string $identifier): string
+    {
+        $identifier = $this->normalize($identifier);
+        $aliases = $this->aliases();
+
+        return Arr::hasKey($aliases, $identifier) ? $aliases[$identifier] : $identifier;
+    }
+
+    private function normalize(string $identifier): string
+    {
+        $identifier = Str::lower(Str::trim($identifier));
+        $identifier = Str::replace($identifier, '-', '_');
+
+        return Str::replace($identifier, ' ', '_');
+    }
+
+    private function normalizeMap(array $map, bool $normalizeValues = false): array
+    {
+        $normalized = Arr::make();
+        foreach ($map as $identifier => $value) {
+            $normalized[$this->normalize((string)$identifier)] = $normalizeValues
+                ? $this->normalize((string)$value)
+                : $value;
+        }
+
+        return $normalized->toArray();
+    }
+}

--- a/src/Wise/Res/WebBrowserResource.php
+++ b/src/Wise/Res/WebBrowserResource.php
@@ -1,6 +1,5 @@
 <?php
 
-// WebBrowserCommand.php
 namespace BlueFission\Wise\Res;
 
 use BlueFission\Services\Service;

--- a/tests/Res/ResourceCatalogTest.php
+++ b/tests/Res/ResourceCatalogTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace BlueFission\Tests\Res;
+
+use BlueFission\Wise\Res\CommandResource;
+use BlueFission\Wise\Res\ResourceCatalog;
+use BlueFission\Wise\Res\SystemResource;
+use BlueFission\Wise\Res\WebBrowserResource;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class ResourceCatalogTest extends TestCase
+{
+    public function testCanonicalDefinitionsReferenceLoadablePsr4Classes(): void
+    {
+        $catalog = new ResourceCatalog();
+
+        $this->assertSame([], $catalog->missingClasses());
+        foreach ($catalog->definitions() as $class) {
+            $reflection = new ReflectionClass($class);
+            $path = str_replace('\\', '/', (string)$reflection->getFileName());
+
+            $this->assertStringEndsWith(
+                '/src/Wise/Res/' . $reflection->getShortName() . '.php',
+                $path
+            );
+        }
+    }
+
+    public function testCoreResourcesUseCanonicalPackageClasses(): void
+    {
+        $catalog = new ResourceCatalog();
+
+        $this->assertSame(SystemResource::class, $catalog->classFor('system'));
+        $this->assertSame(CommandResource::class, $catalog->classFor('command'));
+        $this->assertSame(WebBrowserResource::class, $catalog->classFor('website'));
+        $this->assertSame(WebBrowserResource::class, $catalog->classFor('web'));
+    }
+
+    public function testAbsentCapabilitiesAreExplicitlyUnavailable(): void
+    {
+        $catalog = new ResourceCatalog();
+
+        foreach (['message', 'resource', 'transcript'] as $identifier) {
+            $description = $catalog->describe($identifier);
+
+            $this->assertSame(ResourceCatalog::UNAVAILABLE, $description['status']);
+            $this->assertSame('not_implemented', $description['reason']);
+            $this->assertNull($description['class']);
+        }
+
+        $this->assertSame(ResourceCatalog::UNKNOWN, $catalog->status('not-a-resource'));
+    }
+
+    public function testCatalogCanBeExtendedWithoutChangingCanonicalDefaults(): void
+    {
+        $catalog = new ResourceCatalog(
+            ['custom' => TestResource::class],
+            ['custom-alias' => 'custom']
+        );
+
+        $this->assertSame(TestResource::class, $catalog->classFor('custom'));
+        $this->assertSame(TestResource::class, $catalog->classFor('custom alias'));
+        $this->assertSame(SystemResource::class, $catalog->classFor('system'));
+    }
+}
+
+final class TestResource
+{
+}


### PR DESCRIPTION
## Intent summary

Publish an authoritative, PSR-4-loadable resource catalog so hosts discover package capabilities without constructing class names or inventing compatibility aliases.

## User stories / acceptance criteria

- Resolve system, command, and website capabilities to canonical package classes.
- Align `WebBrowserResource` with its PSR-4 file path.
- Distinguish unavailable message, transcript, and generic resource capabilities from unknown identifiers.
- Allow hosts to extend the catalog through injected definitions and aliases.
- Verify every canonical class through authoritative Composer autoloading.

## Key files changed

- `src/Wise/Res/ResourceCatalog.php`
- `src/Wise/Res/WebBrowserResource.php`
- `tests/Res/ResourceCatalogTest.php`
- `docs/resources.md`

## How to test

```bash
composer validate --strict --no-check-lock --no-check-publish
composer dump-autoload --classmap-authoritative --strict-psr
vendor/bin/phpunit --do-not-cache-result tests/Res/ResourceCatalogTest.php
vendor/bin/phpunit --do-not-cache-result
git diff --check
```

## QA checklist

- [x] Catalog test passes: 4 tests, 40 assertions.
- [x] Full suite passes: 240 tests, 673 assertions, one optional skip.
- [x] Authoritative optimized autoload generation passes.
- [x] Every catalog class resolves to its canonical file.
- [x] Missing capabilities return deterministic unavailable metadata.

## Approval conditions

Merge after PHP 8.2, PHP 8.3, and analysis checks pass. Hosts should consume the catalog and must not add aliases for absent PHP classes.

Closes #47
