### PR TITLE
Preserve immutable command result metadata

### DIFF
--- a/docs/headless-runtime.md
+++ b/docs/headless-runtime.md
@@ -45,7 +45,9 @@ $scriptResult = $runtime->executeScript('cmd/status.jss', $runtimeContext);
 `RuntimeResult::result()` returns the authoritative `CommandResult`. If a
 resource already returns a `CommandResult`, its status, output, diagnostics,
 exit code, prompt state, and continuation token are preserved. Host metadata is
-merged once, with result-owned metadata taking precedence.
+merged once through `CommandResult::withMetadata()`. The method returns a new
+result, leaves the original unchanged, and gives supplied host metadata
+precedence when a key already exists.
 
 `RuntimeResult::frames()` exposes typed status, output, diagnostic, and prompt
 frames. A terminal adapter may render these frames; an application adapter may

--- a/src/Wise/Cmd/CommandResult.php
+++ b/src/Wise/Cmd/CommandResult.php
@@ -156,7 +156,7 @@ class CommandResult extends Obj
             $this->confirmationRequired(),
             $this->exitCode(),
             $this->diagnostics(),
-            Arr::merge($metadata, $this->metadata()),
+            Arr::merge($this->metadata(), $metadata),
             $this->continuationToken()
         );
     }

--- a/tests/CommandResultTest.php
+++ b/tests/CommandResultTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace BlueFission\Tests;
+
+use BlueFission\Wise\Cmd\Command;
+use BlueFission\Wise\Cmd\CommandResult;
+use PHPUnit\Framework\TestCase;
+
+final class CommandResultTest extends TestCase
+{
+    public function testWithMetadataReturnsANewResultWithCallerKeysTakingPrecedence(): void
+    {
+        $result = CommandResult::completed('done', metadata: [
+            'source' => 'resource',
+            'correlation_id' => 'resource-correlation',
+        ]);
+
+        $augmented = $result->withMetadata([
+            'correlation_id' => 'host-correlation',
+            'tenant_id' => 'tenant-1',
+        ]);
+
+        $this->assertNotSame($result, $augmented);
+        $this->assertSame([
+            'source' => 'resource',
+            'correlation_id' => 'resource-correlation',
+        ], $result->metadata());
+        $this->assertSame([
+            'source' => 'resource',
+            'correlation_id' => 'host-correlation',
+            'tenant_id' => 'tenant-1',
+        ], $augmented->metadata());
+    }
+
+    public function testWithMetadataPreservesEveryResultVariant(): void
+    {
+        $command = new Command();
+        $command->verb = 'inspect';
+        $command->resources = ['resource'];
+
+        $results = [
+            CommandResult::completed('done', $command, ['source' => 'completed']),
+            CommandResult::parsed($command, ['source' => 'parsed']),
+            CommandResult::pending('approve?', $command, 'resume-1', ['source' => 'pending']),
+            CommandResult::invalid('invalid', ['invalid_command'], ['source' => 'invalid'], $command),
+            CommandResult::failure('failed', ['handler_failed'], ['source' => 'failed']),
+        ];
+
+        foreach ($results as $result) {
+            $augmented = $result->withMetadata(['host' => 'opus']);
+
+            $this->assertNotSame($result, $augmented);
+            $this->assertSame($result->status(), $augmented->status());
+            $this->assertSame($result->output(), $augmented->output());
+            $this->assertSame($result->command(), $augmented->command());
+            $this->assertSame($result->description(), $augmented->description());
+            $this->assertSame($result->confirmationRequired(), $augmented->confirmationRequired());
+            $this->assertSame($result->exitCode(), $augmented->exitCode());
+            $this->assertSame($result->diagnostics(), $augmented->diagnostics());
+            $this->assertSame($result->continuationToken(), $augmented->continuationToken());
+            $this->assertSame(
+                [...$result->metadata(), 'host' => 'opus'],
+                $augmented->metadata()
+            );
+        }
+    }
+}

--- a/tests/HeadlessCommandProcessorTest.php
+++ b/tests/HeadlessCommandProcessorTest.php
@@ -228,8 +228,8 @@ final class HeadlessCommandProcessorTest extends TestCase
         $this->assertSame('Resource execution failed.', $result->output());
         $this->assertSame(['resource_failure'], $result->diagnostics());
         $this->assertSame([
-            'correlation_id' => 'req-result',
             'source' => 'resource',
+            'correlation_id' => 'req-result',
         ], $result->metadata());
     }
 


### PR DESCRIPTION
## Intent

Make `CommandResult` metadata augmentation immutable and caller-authoritative without losing any command outcome state.

## User stories / acceptance criteria

- [x] Return a distinct `CommandResult` instance when metadata is augmented.
- [x] Preserve status, output, command, confirmation state, exit code, diagnostics, and continuation token.
- [x] Merge metadata with documented caller-supplied key precedence.
- [x] Leave the original result and its metadata unchanged.
- [x] Cover completed, parsed, confirmation-pending, invalid, and failed outcomes.

## Key files changed

- `src/Wise/Cmd/CommandResult.php` gives supplied metadata precedence while preserving immutable result construction.
- `tests/CommandResultTest.php` proves outcome-field preservation, caller precedence, and original-instance immutability.
- `tests/HeadlessCommandProcessorTest.php` aligns stable metadata ordering with the documented precedence contract.
- `docs/headless-runtime.md` documents immutable augmentation and caller-authoritative conflict handling.

## How to test

```powershell
vendor\bin\phpunit.bat --do-not-cache-result tests\CommandResultTest.php tests\HeadlessCommandProcessorTest.php
vendor\bin\phpunit.bat --do-not-cache-result
git diff --check
```

Focused result: 17 tests, 117 assertions.

Full result: 244 tests, 736 assertions, with one expected optional-integration skip.

## QA checklist

- [x] Verified on PHP 8.2 locally.
- [x] Caller-supplied metadata wins on duplicate keys.
- [x] Existing metadata survives non-conflicting augmentation.
- [x] The original result is not mutated.
- [x] Continuation tokens and diagnostics survive augmentation.
- [x] No secrets or environment configuration changed.

## Approval conditions

- PHP 8.2 and PHP 8.3 CI pass.
- Analysis passes.
- No unresolved review comments remain.
- The reviewed head matches the merged head.

Closes #50