### PR TITLE
Add request-scoped command policy

### DIFF
--- a/src/Wise/Cmd/CommandPolicy.php
+++ b/src/Wise/Cmd/CommandPolicy.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace BlueFission\Wise\Cmd;
+
+use BlueFission\Arr;
+use BlueFission\Obj;
+use BlueFission\Str;
+use InvalidArgumentException;
+
+final class CommandPolicy extends Obj
+{
+    public const RESOURCE = 'resource';
+    public const NATIVE = 'native';
+    public const SCRIPT = 'script';
+
+    private Arr $allowlist;
+
+    public function __construct(array $allowlist)
+    {
+        parent::__construct();
+
+        $normalized = Arr::make();
+        foreach ($allowlist as $identifier) {
+            $identifier = $this->normalize((string)$identifier);
+            if (!$this->valid($identifier)) {
+                throw new InvalidArgumentException('Command policy identifiers must use a canonical route prefix.');
+            }
+            $normalized->push($identifier);
+        }
+
+        $this->allowlist = $normalized->unique()->sort();
+    }
+
+    public static function resource(string $resource, string $action): string
+    {
+        return self::identifier(self::RESOURCE, $resource . '.' . $action);
+    }
+
+    public static function native(string $command): string
+    {
+        return self::identifier(self::NATIVE, $command);
+    }
+
+    public static function script(string $extension): string
+    {
+        return self::identifier(self::SCRIPT, $extension);
+    }
+
+    public function allowlist(): array
+    {
+        return $this->allowlist->toArray();
+    }
+
+    public function allows(string $identifier): bool
+    {
+        $identifier = $this->normalize($identifier);
+        foreach ($this->allowlist as $allowed) {
+            if (Str::match((string)$allowed, $identifier)) {
+                return true;
+            }
+            if (Str::endsWith((string)$allowed, '*')
+                && Str::startsWith(
+                    $identifier,
+                    Str::make((string)$allowed)->sub(0, -1)
+                )) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function toArray(): array
+    {
+        return ['allowlist' => $this->allowlist()];
+    }
+
+    private static function identifier(string $route, string $target): string
+    {
+        $route = Str::make($route)->trim()->lower()->val();
+        $target = Str::make($target)
+            ->trim()
+            ->lower()
+            ->replace(' ', '_')
+            ->replace('-', '_')
+            ->val();
+
+        return $route . ':' . $target;
+    }
+
+    private function normalize(string $identifier): string
+    {
+        return Str::make($identifier)
+            ->trim()
+            ->lower()
+            ->replace(' ', '_')
+            ->replace('-', '_')
+            ->val();
+    }
+
+    private function valid(string $identifier): bool
+    {
+        return Str::matches($identifier, '/^(resource:[a-z0-9_*.]+\.[a-z0-9_*]+|native:[a-z0-9_*]+|script:[a-z0-9_*]+)$/');
+    }
+}

--- a/src/Wise/Cmd/CommandRuntime.php
+++ b/src/Wise/Cmd/CommandRuntime.php
@@ -38,6 +38,11 @@ final class CommandRuntime implements ICommandRuntime
 
         if (Str::is($input) && $this->nativeHandler?->canHandle((string)$input)) {
             $commandName = Str::make((string)$input)->trim()->split()->shift();
+            $identifier = CommandPolicy::native((string)$commandName);
+            $denied = $this->denyUnlessAllowed($context, $identifier);
+            if ($denied instanceof RuntimeResult) {
+                return $denied;
+            }
             if (Str::match('clear', Str::lower((string)$commandName))) {
                 return $this->failure(
                     'Screen control is unavailable in headless execution.',
@@ -62,6 +67,12 @@ final class CommandRuntime implements ICommandRuntime
             }
         }
 
+        $identifier = $this->resourceIdentifier($request->input());
+        $denied = $this->denyUnlessAllowed($context, $identifier);
+        if ($denied instanceof RuntimeResult) {
+            return $denied;
+        }
+
         return RuntimeResult::fromCommandResult($this->processor->process($request));
     }
 
@@ -73,6 +84,10 @@ final class CommandRuntime implements ICommandRuntime
         $guard = $this->guard($context);
         if ($guard instanceof RuntimeResult) {
             return $guard;
+        }
+        $denied = $this->denyUnlessAllowed($context, $this->scriptIdentifier($path));
+        if ($denied instanceof RuntimeResult) {
+            return $denied;
         }
         if ($context->workingDirectory() !== null
             && !$context->hasCapability(ExecutionRequest::CAP_FILESYSTEM)) {
@@ -118,7 +133,7 @@ final class CommandRuntime implements ICommandRuntime
         return RuntimeResult::fromCommandResult($result);
     }
 
-    public function discover(): array
+    public function discover(?RuntimeContext $context = null): array
     {
         $resourceCommands = Func::isCallable([$this->processor, 'availableCommands'])
             ? $this->processor->availableCommands()
@@ -126,10 +141,26 @@ final class CommandRuntime implements ICommandRuntime
         $nativeCommands = $this->nativeHandler?->availableCommands() ?? [];
         $scriptExtensions = $this->kernel?->bridgeRegistry()?->extensions() ?? [];
 
+        $resourceCommands = Arr::make($resourceCommands)
+            ->filter(fn ($command) => $this->allowed($context, $this->resourceIdentifier((string)$command)))
+            ->unique()
+            ->sort()
+            ->toArray();
+        $nativeCommands = Arr::make($nativeCommands)
+            ->filter(fn ($command) => $this->allowed($context, CommandPolicy::native((string)$command)))
+            ->unique()
+            ->sort()
+            ->toArray();
+        $scriptExtensions = Arr::make($scriptExtensions)
+            ->filter(fn ($extension) => $this->allowed($context, CommandPolicy::script((string)$extension)))
+            ->unique()
+            ->sort()
+            ->toArray();
+
         return [
-            'commands' => Arr::make($resourceCommands)->unique()->sort()->toArray(),
-            'native' => Arr::make($nativeCommands)->unique()->sort()->toArray(),
-            'script_extensions' => Arr::make($scriptExtensions)->unique()->sort()->toArray(),
+            'commands' => $resourceCommands,
+            'native' => $nativeCommands,
+            'script_extensions' => $scriptExtensions,
         ];
     }
 
@@ -177,5 +208,56 @@ final class CommandRuntime implements ICommandRuntime
         $command = Str::make($input)->trim()->split()->shift();
 
         return Str::match('run', Str::lower((string)$command));
+    }
+
+    private function allowed(?RuntimeContext $context, string $identifier): bool
+    {
+        return !$context instanceof RuntimeContext || $context->allowsCommand($identifier);
+    }
+
+    private function denyUnlessAllowed(RuntimeContext $context, string $identifier): ?RuntimeResult
+    {
+        if ($context->allowsCommand($identifier)) {
+            return null;
+        }
+
+        return $this->failure(
+            'Command is not allowed by the request policy.',
+            ['command_policy_denied', 'identifier' => $identifier],
+            $context
+        );
+    }
+
+    private function resourceIdentifier(Command|array|string $input): string
+    {
+        if ($input instanceof Command) {
+            return CommandPolicy::resource(
+                (string)(Arr::make($input->resources)->shift() ?? ''),
+                (string)$input->verb
+            );
+        }
+        if (Arr::is($input)) {
+            $resource = $input['resource'] ?? $input['objects'] ?? $input['resources'] ?? '';
+            if (Arr::is($resource)) {
+                $resource = Arr::make($resource)->shift();
+            }
+            $action = $input['verb'] ?? $input['operator'] ?? '';
+
+            return CommandPolicy::resource((string)$resource, (string)$action);
+        }
+
+        $parts = Str::make((string)$input)->trim()->split();
+        $action = (string)$parts->shift();
+        $resource = (string)$parts->shift();
+
+        return CommandPolicy::resource($resource, $action);
+    }
+
+    private function scriptIdentifier(string $path): string
+    {
+        $parts = Str::make($path)->split('.');
+        $extension = (string)$parts->pop();
+
+        return CommandPolicy::script($extension);
     }
 }

--- a/src/Wise/Cmd/ICommandRuntime.php
+++ b/src/Wise/Cmd/ICommandRuntime.php
@@ -15,5 +15,5 @@ interface ICommandRuntime
         string $standardInput = ''
     ): RuntimeResult;
 
-    public function discover(): array;
+    public function discover(?RuntimeContext $context = null): array;
 }

--- a/src/Wise/Cmd/RuntimeContext.php
+++ b/src/Wise/Cmd/RuntimeContext.php
@@ -18,6 +18,7 @@ final class RuntimeContext extends Obj
     private Arr $environmentAllowlist;
     private Arr $actor;
     private Arr $capabilities;
+    private ?CommandPolicy $commandPolicy;
     private Num $timeoutMs;
     private ?float $deadlineAt;
     private mixed $cancelCheck;
@@ -33,7 +34,8 @@ final class RuntimeContext extends Obj
         array $capabilities = [],
         int $timeoutMs = 0,
         ?float $deadlineAt = null,
-        ?callable $cancelCheck = null
+        ?callable $cancelCheck = null,
+        ?CommandPolicy $commandPolicy = null
     ) {
         parent::__construct();
         $this->metadata = Arr::make($metadata);
@@ -51,6 +53,7 @@ final class RuntimeContext extends Obj
             ->map(fn ($capability) => Str::make((string)$capability)->trim()->lower()->val())
             ->filter(fn ($capability) => Str::isNotEmpty((string)$capability))
             ->unique();
+        $this->commandPolicy = $commandPolicy;
         $this->timeoutMs = Num::make(Num::max(0, $timeoutMs));
         $this->deadlineAt = $deadlineAt;
         $this->cancelCheck = $cancelCheck;
@@ -59,10 +62,14 @@ final class RuntimeContext extends Obj
 
     public function metadata(): array
     {
-        return Arr::merge($this->metadata->toArray(), [
+        $metadata = Arr::merge($this->metadata->toArray(), [
             'actor' => $this->actor->toArray(),
             'capabilities' => $this->capabilities->toArray(),
         ]);
+
+        return $this->commandPolicy instanceof CommandPolicy
+            ? Arr::merge($metadata, ['command_policy' => $this->commandPolicy->toArray()])
+            : $metadata;
     }
 
     public function arguments(): array
@@ -96,6 +103,17 @@ final class RuntimeContext extends Obj
     public function hasCapability(string $capability): bool
     {
         return $this->capabilities->has(Str::lower($capability), true);
+    }
+
+    public function commandPolicy(): ?CommandPolicy
+    {
+        return $this->commandPolicy;
+    }
+
+    public function allowsCommand(string $identifier): bool
+    {
+        return !$this->commandPolicy instanceof CommandPolicy
+            || $this->commandPolicy->allows($identifier);
     }
 
     public function cancelled(): bool

--- a/tests/CommandRuntimeTest.php
+++ b/tests/CommandRuntimeTest.php
@@ -5,6 +5,7 @@ namespace BlueFission\Tests;
 use BlueFission\Arr;
 use BlueFission\Wise\Arc\Kernel;
 use BlueFission\Wise\Cmd\CommandHandler;
+use BlueFission\Wise\Cmd\CommandPolicy;
 use BlueFission\Wise\Cmd\CommandRequest;
 use BlueFission\Wise\Cmd\CommandResult;
 use BlueFission\Wise\Cmd\CommandRuntime;
@@ -13,7 +14,11 @@ use BlueFission\Wise\Cmd\ICommandRuntime;
 use BlueFission\Wise\Cmd\OutputFrame;
 use BlueFission\Wise\Cmd\RuntimeContext;
 use BlueFission\Wise\Exe\BridgeResult;
+use BlueFission\Wise\Exe\BridgeContext;
+use BlueFission\Wise\Exe\BridgeRegistry;
 use BlueFission\Wise\Exe\ExecutionRequest;
+use BlueFission\Wise\Exe\IBridge;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 final class CommandRuntimeTest extends TestCase
@@ -179,6 +184,134 @@ final class CommandRuntimeTest extends TestCase
         $this->assertSame(OutputFrame::PROMPT, $prompt['type']);
         $this->assertSame('continuation-1', $prompt['metadata']['continuation_token']);
         $this->assertSame('confirmation-1', $result->result()->metadata()['correlation_id']);
+    }
+
+    public function testPolicyDeniesBeforeResourceDispatchAndPreservesHostContext(): void
+    {
+        $processor = $this->processor();
+        $runtime = new CommandRuntime($processor);
+        $context = new RuntimeContext(
+            ['correlation_id' => 'policy-denied'],
+            actor: ['id' => 'actor-1'],
+            capabilities: ['read'],
+            commandPolicy: new CommandPolicy(['resource:item.list'])
+        );
+
+        $result = $runtime->execute('inspect resource', $context)->result();
+
+        $this->assertSame(CommandResult::FAILED, $result->status());
+        $this->assertSame([
+            'command_policy_denied',
+            'identifier' => 'resource:resource.inspect',
+        ], $result->diagnostics());
+        $this->assertSame(0, $processor->calls);
+        $this->assertSame('policy-denied', $result->metadata()['correlation_id']);
+        $this->assertSame('actor-1', $result->metadata()['actor']['id']);
+        $this->assertSame(['read'], $result->metadata()['capabilities']);
+        $this->assertSame(
+            ['allowlist' => ['resource:item.list']],
+            $result->metadata()['command_policy']
+        );
+    }
+
+    public function testPolicyFiltersDiscoveryAcrossResourceNativeAndScriptRoutes(): void
+    {
+        $handler = new class extends CommandHandler {
+            public function __construct()
+            {
+            }
+
+            public function availableCommands(): array
+            {
+                return ['echo', 'help'];
+            }
+        };
+        $registry = new BridgeRegistry();
+        $registry->register(new class implements IBridge {
+            public function name(): string
+            {
+                return 'test';
+            }
+
+            public function extensions(): array
+            {
+                return ['jss', 'vibe'];
+            }
+
+            public function canHandleFile(string $path): bool
+            {
+                return true;
+            }
+
+            public function runFile(string $path, BridgeContext $context): BridgeResult
+            {
+                return BridgeResult::success();
+            }
+
+            public function runSource(string $source, BridgeContext $context, ?string $path = null): BridgeResult
+            {
+                return BridgeResult::success();
+            }
+        });
+        $kernel = new class($registry) extends Kernel {
+            public function __construct(private BridgeRegistry $registry)
+            {
+            }
+
+            public function bridgeRegistry(): ?BridgeRegistry
+            {
+                return $this->registry;
+            }
+        };
+        $processor = new class implements ICommandProcessor {
+            public function process(CommandRequest|\BlueFission\Wise\Cmd\Command|array|string $request): CommandResult
+            {
+                return CommandResult::completed('processed');
+            }
+
+            public function availableCommands(): array
+            {
+                return ['inspect resource', 'list item'];
+            }
+        };
+        $runtime = new CommandRuntime($processor, $handler, $kernel);
+        $context = new RuntimeContext(commandPolicy: new CommandPolicy([
+            'resource:resource.inspect',
+            'native:help',
+            'script:jss',
+        ]));
+
+        $this->assertSame([
+            'commands' => ['inspect resource'],
+            'native' => ['help'],
+            'script_extensions' => ['jss'],
+        ], $runtime->discover($context));
+    }
+
+    public function testPolicyIsRequestScopedAcrossSharedRuntime(): void
+    {
+        $processor = $this->processor();
+        $runtime = new CommandRuntime($processor);
+        $allowed = new RuntimeContext(commandPolicy: new CommandPolicy(['resource:resource.*']));
+        $denied = new RuntimeContext(commandPolicy: new CommandPolicy(['native:help']));
+
+        $first = $runtime->execute('inspect resource', $allowed)->result();
+        $second = $runtime->execute('inspect resource', $denied)->result();
+        $third = $runtime->execute('inspect resource', $allowed)->result();
+
+        $this->assertSame(CommandResult::COMPLETED, $first->status());
+        $this->assertSame(CommandResult::FAILED, $second->status());
+        $this->assertSame(CommandResult::COMPLETED, $third->status());
+        $this->assertSame(2, $processor->calls);
+        $this->assertSame(['inspect resource'], $runtime->discover($allowed)['commands']);
+        $this->assertSame([], $runtime->discover($denied)['commands']);
+    }
+
+    public function testPolicyRejectsMalformedIdentifiers(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new CommandPolicy(['inspect resource']);
     }
 
     private function processor(): ICommandProcessor


### PR DESCRIPTION
Request-scoped resource, native, and script policy with deny-before-dispatch and filtered discovery. Full suite: 248 tests, 751 assertions. Closes #51.