### PR TITLE
Publish host-neutral command descriptors

### DIFF
--- a/src/Wise/Cmd/CommandDescriptor.php
+++ b/src/Wise/Cmd/CommandDescriptor.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace BlueFission\Wise\Cmd;
+
+use BlueFission\Arr;
+use BlueFission\Flag;
+use BlueFission\Obj;
+use BlueFission\Str;
+
+final class CommandDescriptor extends Obj
+{
+    private Str $identifier;
+    private Str $route;
+    private ?Str $resource;
+    private ?Str $action;
+    private Str $summary;
+    private Arr $argumentShape;
+    private Flag $confirmationRequired;
+    private Arr $requiredCapabilities;
+    private Flag $available;
+    private ?Str $unavailableReason;
+
+    public function __construct(
+        string $identifier,
+        string $route,
+        ?string $resource,
+        ?string $action,
+        string $summary,
+        array $argumentShape = [],
+        bool $confirmationRequired = false,
+        array $requiredCapabilities = [],
+        bool $available = true,
+        ?string $unavailableReason = null
+    ) {
+        parent::__construct();
+        $this->identifier = Str::make($identifier)->trim()->lower();
+        $this->route = Str::make($route)->trim()->lower();
+        $this->resource = Str::isNotEmpty((string)$resource)
+            ? Str::make((string)$resource)->trim()->lower()
+            : null;
+        $this->action = Str::isNotEmpty((string)$action)
+            ? Str::make((string)$action)->trim()->lower()
+            : null;
+        $this->summary = Str::make($summary)->trim();
+        $this->argumentShape = Arr::make($argumentShape);
+        $this->confirmationRequired = Flag::make($confirmationRequired);
+        $this->requiredCapabilities = Arr::make($requiredCapabilities)
+            ->map(fn ($capability) => Str::make((string)$capability)->trim()->lower()->val())
+            ->filter(fn ($capability) => Str::isNotEmpty((string)$capability))
+            ->unique()
+            ->sort();
+        $this->available = Flag::make($available);
+        $this->unavailableReason = Str::isNotEmpty((string)$unavailableReason)
+            ? Str::make((string)$unavailableReason)->trim()->lower()
+            : null;
+    }
+
+    public static function resource(string $command, array $definition = []): self
+    {
+        $parts = Str::make($command)->trim()->split();
+        $action = (string)$parts->shift();
+        $resource = (string)$parts->shift();
+
+        return new self(
+            CommandPolicy::resource($resource, $action),
+            CommandPolicy::RESOURCE,
+            $resource,
+            $action,
+            (string)($definition['summary'] ?? Str::make($action . ' ' . $resource)->capitalize()->val()),
+            $definition['argument_shape'] ?? [
+                'type' => 'object',
+                'additional_properties' => true,
+            ],
+            (bool)($definition['confirmation_required'] ?? false),
+            $definition['required_capabilities'] ?? []
+        );
+    }
+
+    public static function native(string $command, array $definition = []): self
+    {
+        $command = Str::make($command)->trim()->lower()->val();
+
+        return new self(
+            CommandPolicy::native($command),
+            CommandPolicy::NATIVE,
+            null,
+            $command,
+            (string)($definition['summary'] ?? Str::make('Run ' . $command)->capitalize()->val()),
+            $definition['argument_shape'] ?? [
+                'type' => 'array',
+                'items' => ['type' => 'string'],
+            ],
+            (bool)($definition['confirmation_required'] ?? false),
+            $definition['required_capabilities'] ?? []
+        );
+    }
+
+    public static function script(string $extension, array $definition = []): self
+    {
+        $extension = Str::make($extension)->trim()->lower()->val();
+
+        return new self(
+            CommandPolicy::script($extension),
+            CommandPolicy::SCRIPT,
+            null,
+            'run',
+            (string)($definition['summary'] ?? Str::make('Run .' . $extension . ' script')->capitalize()->val()),
+            $definition['argument_shape'] ?? [
+                'type' => 'object',
+                'properties' => [
+                    'path' => ['type' => 'string', 'required' => true],
+                    'arguments' => ['type' => 'array', 'items' => ['type' => 'string']],
+                    'standard_input' => ['type' => 'string'],
+                ],
+            ],
+            (bool)($definition['confirmation_required'] ?? false),
+            $definition['required_capabilities'] ?? []
+        );
+    }
+
+    public static function unavailable(string $identifier, string $reason = 'not_discovered'): self
+    {
+        $parts = Str::make($identifier)->trim()->lower()->split(':');
+        $route = (string)$parts->shift();
+        $target = (string)$parts->shift();
+        $resource = null;
+        $action = $target;
+        if (Str::match(CommandPolicy::RESOURCE, $route)) {
+            $targetParts = Str::make($target)->split('.');
+            $resource = (string)$targetParts->shift();
+            $action = (string)$targetParts->shift();
+        }
+
+        return new self(
+            $identifier,
+            $route,
+            $resource,
+            $action,
+            'Command is unavailable',
+            available: false,
+            unavailableReason: $reason
+        );
+    }
+
+    public function identifier(): string
+    {
+        return $this->identifier->val();
+    }
+
+    public function available(): bool
+    {
+        return $this->available->isTruthy();
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'identifier' => $this->identifier(),
+            'route' => $this->route->val(),
+            'resource' => $this->resource?->val(),
+            'action' => $this->action?->val(),
+            'summary' => $this->summary->val(),
+            'argument_shape' => $this->argumentShape->toArray(),
+            'confirmation_required' => $this->confirmationRequired->isTruthy(),
+            'required_capabilities' => $this->requiredCapabilities->toArray(),
+            'available' => $this->available(),
+            'unavailable_reason' => $this->unavailableReason?->val(),
+        ];
+    }
+}

--- a/src/Wise/Cmd/CommandRuntime.php
+++ b/src/Wise/Cmd/CommandRuntime.php
@@ -164,6 +164,48 @@ final class CommandRuntime implements ICommandRuntime
         ];
     }
 
+    public function descriptors(?RuntimeContext $context = null): array
+    {
+        $discovery = $this->discover($context);
+        $descriptors = Arr::make();
+        foreach ($discovery['commands'] as $command) {
+            $descriptors->push(CommandDescriptor::resource((string)$command)->toArray());
+        }
+        foreach ($discovery['native'] as $command) {
+            $descriptors->push(CommandDescriptor::native((string)$command)->toArray());
+        }
+        foreach ($discovery['script_extensions'] as $extension) {
+            $descriptors->push(CommandDescriptor::script((string)$extension)->toArray());
+        }
+
+        return $descriptors
+            ->sort(fn (array $left, array $right): int => $left['identifier'] <=> $right['identifier'])
+            ->toArray();
+    }
+
+    public function descriptor(string $identifier, ?RuntimeContext $context = null): CommandDescriptor
+    {
+        $identifier = Str::make($identifier)->trim()->lower()->val();
+        foreach ($this->descriptors($context) as $descriptor) {
+            if (Str::match($identifier, (string)$descriptor['identifier'])) {
+                return new CommandDescriptor(
+                    $descriptor['identifier'],
+                    $descriptor['route'],
+                    $descriptor['resource'],
+                    $descriptor['action'],
+                    $descriptor['summary'],
+                    $descriptor['argument_shape'],
+                    $descriptor['confirmation_required'],
+                    $descriptor['required_capabilities'],
+                    $descriptor['available'],
+                    $descriptor['unavailable_reason']
+                );
+            }
+        }
+
+        return CommandDescriptor::unavailable($identifier);
+    }
+
     private function withContext(
         CommandRequest|Command|array|string $request,
         RuntimeContext $context

--- a/src/Wise/Cmd/ICommandRuntime.php
+++ b/src/Wise/Cmd/ICommandRuntime.php
@@ -16,4 +16,8 @@ interface ICommandRuntime
     ): RuntimeResult;
 
     public function discover(?RuntimeContext $context = null): array;
+
+    public function descriptors(?RuntimeContext $context = null): array;
+
+    public function descriptor(string $identifier, ?RuntimeContext $context = null): CommandDescriptor;
 }

--- a/tests/CommandRuntimeTest.php
+++ b/tests/CommandRuntimeTest.php
@@ -5,6 +5,7 @@ namespace BlueFission\Tests;
 use BlueFission\Arr;
 use BlueFission\Wise\Arc\Kernel;
 use BlueFission\Wise\Cmd\CommandHandler;
+use BlueFission\Wise\Cmd\CommandDescriptor;
 use BlueFission\Wise\Cmd\CommandPolicy;
 use BlueFission\Wise\Cmd\CommandRequest;
 use BlueFission\Wise\Cmd\CommandResult;
@@ -312,6 +313,89 @@ final class CommandRuntimeTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         new CommandPolicy(['inspect resource']);
+    }
+
+    public function testDescriptorSerializesStableHostNeutralContract(): void
+    {
+        $descriptor = CommandDescriptor::resource('inspect resource', [
+            'summary' => 'Inspect a resource',
+            'argument_shape' => ['type' => 'object', 'required' => ['name']],
+            'confirmation_required' => true,
+            'required_capabilities' => ['READ', 'read'],
+        ]);
+        $serialized = $descriptor->toArray();
+        $serialized['summary'] = 'mutated';
+
+        $this->assertSame([
+            'identifier' => 'resource:resource.inspect',
+            'route' => 'resource',
+            'resource' => 'resource',
+            'action' => 'inspect',
+            'summary' => 'Inspect a resource',
+            'argument_shape' => ['type' => 'object', 'required' => ['name']],
+            'confirmation_required' => true,
+            'required_capabilities' => ['read'],
+            'available' => true,
+            'unavailable_reason' => null,
+        ], $descriptor->toArray());
+    }
+
+    public function testDescriptorsAreOrderedAndFilteredWithoutEmbeddingPolicy(): void
+    {
+        $handler = new class extends CommandHandler {
+            public function __construct()
+            {
+            }
+
+            public function availableCommands(): array
+            {
+                return ['help', 'echo'];
+            }
+        };
+        $processor = new class implements ICommandProcessor {
+            public function process(CommandRequest|\BlueFission\Wise\Cmd\Command|array|string $request): CommandResult
+            {
+                return CommandResult::completed('processed');
+            }
+
+            public function availableCommands(): array
+            {
+                return ['list item', 'inspect resource'];
+            }
+        };
+        $runtime = new CommandRuntime($processor, $handler);
+        $context = new RuntimeContext(commandPolicy: new CommandPolicy([
+            'resource:resource.inspect',
+            'native:help',
+        ]));
+        $descriptors = $runtime->descriptors($context);
+
+        $this->assertSame([
+            'native:help',
+            'resource:resource.inspect',
+        ], Arr::make($descriptors)->map(fn (array $descriptor): string => $descriptor['identifier'])->toArray());
+        $this->assertArrayNotHasKey('command_policy', $descriptors[0]);
+        $this->assertSame('native', $descriptors[0]['route']);
+        $this->assertSame('resource', $descriptors[1]['route']);
+        $this->assertSame([
+            'commands' => ['inspect resource'],
+            'native' => ['help'],
+            'script_extensions' => [],
+        ], $runtime->discover($context));
+    }
+
+    public function testDescriptorLookupReportsUnavailableRouteWithoutExecution(): void
+    {
+        $processor = $this->processor();
+        $runtime = new CommandRuntime($processor);
+
+        $descriptor = $runtime->descriptor('script:jss');
+
+        $this->assertFalse($descriptor->available());
+        $this->assertSame('script:jss', $descriptor->toArray()['identifier']);
+        $this->assertSame('script', $descriptor->toArray()['route']);
+        $this->assertSame('not_discovered', $descriptor->toArray()['unavailable_reason']);
+        $this->assertSame(0, $processor->calls);
     }
 
     private function processor(): ICommandProcessor


### PR DESCRIPTION
## Intent

Publish stable, immutable command descriptors for resource, native, and script routes while retaining the legacy discovery arrays.

## User stories and acceptance criteria

- Hosts receive canonical identifiers, route ownership, summaries, argument shapes, confirmation requirements, and required capabilities.
- Descriptor serialization is stable and presentation neutral.
- Descriptor discovery does not execute commands or boot terminal state.
- Request policy filters descriptor visibility without becoming descriptor data.
- Unknown routes return explicit unavailable descriptors.

## Key files

- `src/Wise/Cmd/CommandDescriptor.php`
- `src/Wise/Cmd/ICommandRuntime.php`
- `src/Wise/Cmd/CommandRuntime.php`
- `tests/CommandRuntimeTest.php`

## How to test

```console
php vendor/bin/phpunit --do-not-cache-result tests/CommandRuntimeTest.php
php vendor/bin/phpunit --do-not-cache-result
git diff --check
```

Focused proof: 13 tests, 54 assertions.

Full proof: 251 tests, 762 assertions, one expected optional skip.

## QA checklist

- [x] Stable descriptor key order and normalized capability values.
- [x] Explicit resource, native, and script ownership.
- [x] Deterministic identifier ordering.
- [x] Policy-filtered visibility with no policy payload leakage.
- [x] Unavailable route lookup performs no execution.
- [x] Legacy discovery arrays remain unchanged.

## Approval conditions

- CI passes on PHP 8.2 and 8.3.
- Review confirms the public descriptor field names.
- Land after PR #57 because this branch uses its request policy contract.

Closes #52
