### PR TITLE
Inject resumable continuation state storage

### DIFF
--- a/src/Wise/Cmd/CommandProcessor.php
+++ b/src/Wise/Cmd/CommandProcessor.php
@@ -28,6 +28,7 @@ class CommandProcessor implements ICommandProcessor
     protected ?Command $_lastCommand = null;
     protected ?string $_lastResource = null;
     protected bool $_confirmationRequired = false;
+    protected IContinuationStore $_continuationStore;
 
     protected $_availableCommands = [];
 
@@ -38,13 +39,19 @@ class CommandProcessor implements ICommandProcessor
 
     protected $_keywords = [];
 
-    public function __construct(Storage $storage, IClient $llmClient = null, INavigator $navigator = null)
+    public function __construct(
+        Storage $storage,
+        IClient $llmClient = null,
+        INavigator $navigator = null,
+        ?IContinuationStore $continuationStore = null
+    )
     {
         $this->setKeywords();
         $this->_parser = new CommandParser();
         $this->_app = App::instance();
         $this->_storage = $storage;
         $this->_storage->activate();
+        $this->_continuationStore = $continuationStore ?? new StorageContinuationStore($storage);
 
         $this->_llmClient = $llmClient;
         $this->_navigator = $navigator;
@@ -425,7 +432,7 @@ class CommandProcessor implements ICommandProcessor
             return CommandResult::pending(
                 $output,
                 $this->_lastCommand,
-                $this->continuationToken(),
+                $this->continuationToken($metadata),
                 $metadata
             );
         }
@@ -433,52 +440,46 @@ class CommandProcessor implements ICommandProcessor
         return CommandResult::completed($output, $this->_lastCommand, $metadata);
     }
 
-    private function continuationToken(): string
+    private function continuationToken(array $metadata): string
     {
-        $token = $this->_storage->confirmToken ?? null;
-        if (Str::isNotEmpty((string)$token)) {
-            return (string)$token;
-        }
+        $pending = $this->_storage->confirmCmd ?? $this->_lastCommand;
+        $command = $pending instanceof Command
+            ? $pending
+            : $this->convertToCommand($pending);
+        $state = ContinuationState::issue($command->toArray(), $metadata);
+        $this->_continuationStore->put($state);
 
-        $token = Str::uuid4();
-        $this->_storage->confirmToken = $token;
-        $this->_storage->write();
-
-        return $token;
+        return $state->token();
     }
 
     private function resume(CommandRequest $request): CommandResult
     {
-        $token = (string)$request->continuationToken();
-        $consumed = Arr::is($this->_storage->consumedContinuations ?? null)
-            ? $this->_storage->consumedContinuations
-            : [];
-
-        if (Arr::has($consumed, $token, true)) {
-            return CommandResult::invalid(
-                'Command continuation has already been consumed.',
-                ['continuation_consumed'],
-                $request->context()
-            );
-        }
-
-        $expected = (string)($this->_storage->confirmToken ?? '');
-        if (Str::isEmpty($expected) || !Str::match($expected, $token)) {
+        $claim = $this->_continuationStore->consume(
+            (string)$request->continuationToken(),
+            ContinuationState::scopeFromContext($request->context())
+        );
+        if (!$claim->accepted()) {
+            $diagnostic = match ($claim->status()) {
+                ContinuationClaim::REPLAYED => 'continuation_consumed',
+                ContinuationClaim::EXPIRED => 'continuation_expired',
+                ContinuationClaim::MISMATCHED => 'continuation_scope_mismatch',
+                default => 'continuation_invalid',
+            };
             return CommandResult::invalid(
                 'Command continuation is invalid.',
-                ['continuation_invalid'],
+                [$diagnostic],
                 $request->context()
             );
         }
 
-        $consumed[] = $token;
-        $consumed = Arr::make($consumed)->slice(-50)->toArray();
-        $this->_storage->consumedContinuations = $consumed;
-        unset($this->_storage->confirmToken);
+        $state = $claim->state();
+        $this->_storage->confirmCmd = $state?->command() ?? [];
         $this->_storage->write();
-
         $output = $this->handle($request->approved() ? 'yes' : 'no');
-        return $this->resultForOutput($output, $request->context());
+        return $this->resultForOutput($output, Arr::merge(
+            $state?->metadata() ?? [],
+            $request->context()
+        ));
     }
 
     public function suggestCommands($input, &$cmd)

--- a/src/Wise/Cmd/ContinuationClaim.php
+++ b/src/Wise/Cmd/ContinuationClaim.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace BlueFission\Wise\Cmd;
+
+use BlueFission\Obj;
+use BlueFission\Str;
+
+final class ContinuationClaim extends Obj
+{
+    public const ACCEPTED = 'accepted';
+    public const MISSING = 'missing';
+    public const EXPIRED = 'expired';
+    public const MISMATCHED = 'mismatched';
+    public const REPLAYED = 'replayed';
+
+    private Str $status;
+
+    public function __construct(string $status, private ?ContinuationState $state = null)
+    {
+        parent::__construct();
+        $this->status = Str::make($status)->trim()->lower();
+    }
+
+    public function status(): string
+    {
+        return $this->status->val();
+    }
+
+    public function accepted(): bool
+    {
+        return Str::match(self::ACCEPTED, $this->status());
+    }
+
+    public function state(): ?ContinuationState
+    {
+        return $this->state;
+    }
+}

--- a/src/Wise/Cmd/ContinuationState.php
+++ b/src/Wise/Cmd/ContinuationState.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace BlueFission\Wise\Cmd;
+
+use BlueFission\Arr;
+use BlueFission\Num;
+use BlueFission\Obj;
+use BlueFission\Str;
+use BlueFission\Val;
+
+final class ContinuationState extends Obj
+{
+    private Str $token;
+    private Arr $command;
+    private Arr $metadata;
+    private Arr $scope;
+    private Num $expiresAt;
+
+    public function __construct(
+        string $token,
+        array $command,
+        array $metadata,
+        array $scope,
+        float $expiresAt
+    ) {
+        parent::__construct();
+        $this->token = Str::make($token)->trim();
+        $this->command = Arr::make($command);
+        $this->metadata = Arr::make($metadata);
+        $this->scope = Arr::make($scope);
+        $this->expiresAt = Num::make($expiresAt);
+    }
+
+    public static function issue(array $command, array $metadata, int $ttlSeconds = 900): self
+    {
+        return new self(
+            Str::uuid4(),
+            $command,
+            $metadata,
+            self::scopeFromContext($metadata),
+            microtime(true) + Num::max(1, $ttlSeconds)
+        );
+    }
+
+    public static function fromArray(array $state): self
+    {
+        return new self(
+            (string)($state['token'] ?? ''),
+            Arr::is($state['command'] ?? null) ? $state['command'] : [],
+            Arr::is($state['metadata'] ?? null) ? $state['metadata'] : [],
+            Arr::is($state['scope'] ?? null) ? $state['scope'] : [],
+            (float)($state['expires_at'] ?? 0)
+        );
+    }
+
+    public static function scopeFromContext(array $context): array
+    {
+        $scope = Arr::make();
+        $actor = Arr::is($context['actor'] ?? null) ? $context['actor'] : [];
+        $values = [
+            'actor_id' => $actor['id'] ?? null,
+            'agent_id' => $context['agent_id'] ?? null,
+            'tenant_id' => $context['tenant_id'] ?? null,
+            'profile_id' => $context['profile_id'] ?? null,
+        ];
+        foreach ($values as $key => $value) {
+            if (Val::isNotEmpty($value)) {
+                $scope[$key] = (string)$value;
+            }
+        }
+
+        return $scope->toArray();
+    }
+
+    public function token(): string
+    {
+        return $this->token->val();
+    }
+
+    public function command(): array
+    {
+        return $this->command->toArray();
+    }
+
+    public function metadata(): array
+    {
+        return $this->metadata->toArray();
+    }
+
+    public function matches(array $scope): bool
+    {
+        return $this->scope->toArray() === $scope;
+    }
+
+    public function expired(?float $now = null): bool
+    {
+        return ($now ?? microtime(true)) >= $this->expiresAt->val();
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'token' => $this->token(),
+            'command' => $this->command(),
+            'metadata' => $this->metadata(),
+            'scope' => $this->scope->toArray(),
+            'expires_at' => $this->expiresAt->val(),
+        ];
+    }
+}

--- a/src/Wise/Cmd/IContinuationStore.php
+++ b/src/Wise/Cmd/IContinuationStore.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace BlueFission\Wise\Cmd;
+
+interface IContinuationStore
+{
+    public function put(ContinuationState $state): void;
+
+    public function consume(string $token, array $scope = []): ContinuationClaim;
+}

--- a/src/Wise/Cmd/StorageContinuationStore.php
+++ b/src/Wise/Cmd/StorageContinuationStore.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace BlueFission\Wise\Cmd;
+
+use BlueFission\Arr;
+use BlueFission\Data\Storage\Storage;
+use BlueFission\Obj;
+
+final class StorageContinuationStore extends Obj implements IContinuationStore
+{
+    public function __construct(private Storage $storage, private int $replayLimit = 50)
+    {
+        parent::__construct();
+        $this->storage->activate();
+        $this->storage->read();
+    }
+
+    public function put(ContinuationState $state): void
+    {
+        $pending = Arr::is($this->storage->continuationStates ?? null)
+            ? $this->storage->continuationStates
+            : [];
+        $pending[$state->token()] = $state->toArray();
+        $this->storage->continuationStates = $pending;
+        $this->storage->write();
+    }
+
+    public function consume(string $token, array $scope = []): ContinuationClaim
+    {
+        $consumed = Arr::is($this->storage->consumedContinuations ?? null)
+            ? $this->storage->consumedContinuations
+            : [];
+        if (Arr::has($consumed, $token, true)) {
+            return new ContinuationClaim(ContinuationClaim::REPLAYED);
+        }
+
+        $pending = Arr::is($this->storage->continuationStates ?? null)
+            ? $this->storage->continuationStates
+            : [];
+        if (!Arr::hasKey($pending, $token) || !Arr::is($pending[$token])) {
+            return new ContinuationClaim(ContinuationClaim::MISSING);
+        }
+
+        $state = ContinuationState::fromArray($pending[$token]);
+        if ($state->expired()) {
+            unset($pending[$token]);
+            $this->storage->continuationStates = $pending;
+            $this->storage->write();
+            return new ContinuationClaim(ContinuationClaim::EXPIRED);
+        }
+        if (!$state->matches($scope)) {
+            return new ContinuationClaim(ContinuationClaim::MISMATCHED);
+        }
+
+        unset($pending[$token]);
+        $consumed = Arr::make($consumed)->push($token)->slice(-$this->replayLimit)->toArray();
+        $this->storage->continuationStates = $pending;
+        $this->storage->consumedContinuations = $consumed;
+        $this->storage->write();
+
+        return new ContinuationClaim(ContinuationClaim::ACCEPTED, $state);
+    }
+}

--- a/tests/HeadlessCommandProcessorTest.php
+++ b/tests/HeadlessCommandProcessorTest.php
@@ -8,6 +8,9 @@ use BlueFission\Wise\Cmd\Command;
 use BlueFission\Wise\Cmd\CommandProcessor;
 use BlueFission\Wise\Cmd\CommandRequest;
 use BlueFission\Wise\Cmd\CommandResult;
+use BlueFission\Wise\Cmd\ContinuationClaim;
+use BlueFission\Wise\Cmd\ContinuationState;
+use BlueFission\Wise\Cmd\StorageContinuationStore;
 use PHPUnit\Framework\TestCase;
 
 final class HeadlessCommandProcessorTest extends TestCase
@@ -176,6 +179,79 @@ final class HeadlessCommandProcessorTest extends TestCase
         $this->assertSame(CommandResult::COMPLETED, $rejected->status());
         $this->assertSame('Command cancelled.', $rejected->output());
         $this->assertSame(3, $executions);
+    }
+
+    public function testContinuationCanResumeInNewProcessorWithSharedStore(): void
+    {
+        $executions = 0;
+        App::instance()->register('persistent-continuation', 'inspect', function () use (&$executions): void {
+            $executions++;
+        });
+        $continuationStore = new StorageContinuationStore($this->makeStorage());
+        $first = new CommandProcessor($this->makeStorage(), continuationStore: $continuationStore);
+        $input = ['verb' => 'inspect', 'resource' => 'persistent-continuation'];
+        $context = ['actor' => ['id' => 'actor-1'], 'tenant_id' => 'tenant-1', 'request_id' => 'first'];
+
+        $first->process(new CommandRequest($input, context: $context));
+        $first->process(new CommandRequest($input, context: $context));
+        $first->process(new CommandRequest($input, context: $context));
+        $pending = $first->process(new CommandRequest($input, context: $context));
+
+        $second = new CommandProcessor($this->makeStorage(), continuationStore: $continuationStore);
+        $completed = $second->process(CommandRequest::resume(
+            (string)$pending->continuationToken(),
+            true,
+            ['actor' => ['id' => 'actor-1'], 'tenant_id' => 'tenant-1', 'request_id' => 'second']
+        ));
+
+        $this->assertSame(CommandResult::COMPLETED, $completed->status());
+        $this->assertSame(4, $executions);
+        $this->assertSame('second', $completed->metadata()['request_id']);
+        $this->assertSame('actor-1', $completed->metadata()['actor']['id']);
+    }
+
+    public function testContinuationScopeMismatchFailsClosedWithoutConsumption(): void
+    {
+        $executions = 0;
+        App::instance()->register('scoped-continuation', 'inspect', function () use (&$executions): void {
+            $executions++;
+        });
+        $store = new StorageContinuationStore($this->makeStorage());
+        $processor = new CommandProcessor($this->makeStorage(), continuationStore: $store);
+        $input = ['verb' => 'inspect', 'resource' => 'scoped-continuation'];
+        $context = ['actor' => ['id' => 'actor-1']];
+        for ($attempt = 0; $attempt < 4; $attempt++) {
+            $pending = $processor->process(new CommandRequest($input, context: $context));
+        }
+
+        $mismatched = $processor->process(CommandRequest::resume(
+            (string)$pending->continuationToken(),
+            true,
+            ['actor' => ['id' => 'actor-2']]
+        ));
+        $accepted = $processor->process(CommandRequest::resume(
+            (string)$pending->continuationToken(),
+            true,
+            $context
+        ));
+
+        $this->assertSame(['continuation_scope_mismatch'], $mismatched->diagnostics());
+        $this->assertSame(CommandResult::COMPLETED, $accepted->status());
+        $this->assertSame(4, $executions);
+    }
+
+    public function testContinuationStoreDistinguishesExpiredMissingAndReplayedTokens(): void
+    {
+        $store = new StorageContinuationStore($this->makeStorage(), replayLimit: 2);
+        $expired = new ContinuationState('expired', [], [], [], microtime(true) - 1);
+        $accepted = new ContinuationState('accepted', [], [], [], microtime(true) + 60);
+        $store->put($expired);
+        $store->put($accepted);
+
+        $this->assertSame(ContinuationClaim::EXPIRED, $store->consume('expired')->status());
+        $this->assertSame(ContinuationClaim::MISSING, $store->consume('missing')->status());
+        $this->assertSame(ContinuationClaim::ACCEPTED, $store->consume('accepted')->status());
+        $this->assertSame(ContinuationClaim::REPLAYED, $store->consume('accepted')->status());
     }
 
     public function testUnhandledFailuresReturnSanitizedResult(): void


### PR DESCRIPTION
## Intent
Inject a package-owned continuation store for resumable, replay-safe command confirmation across processor instances.

## Acceptance
- Rehydrate pending commands in a new processor.
- Consume approvals and rejections exactly once.
- Fail closed for missing, expired, mismatched, and replayed tokens.
- Preserve request metadata with caller-authoritative resume context.
- Bound replay records.

## Tests
Focused: 18 tests, 75 assertions. Full: 254 tests, 773 assertions, one expected skip. Run php vendor/bin/phpunit --do-not-cache-result.

## QA
PHP 8.2 compatible; DevElation Storage default retained; no token contents expose command data.

## Approval
CI must pass PHP 8.2/8.3. Land after PR #58.

Closes #53