### PR TITLE
Stabilize dynamic CLI boot rendering

### DIFF
--- a/examples/terminal.php
+++ b/examples/terminal.php
@@ -304,11 +304,12 @@ if (!$batchMode) {
     $splash = new Components\SplashScreen();
     $repl = new Components\REPL();
     $screen = new Components\Screen();
-    $screen->addChild($repl);
     if ($dynamicDisplay) {
-        $statusLine = new Components\StatusLine(0, 0, 1, 2, '', 10, true, 2);
+        $statusLine = new Components\StatusLine(0, 0, 1, 2, 'Loading W.I.S.E...', 10, true, 2);
         $screen->addChild($statusLine);
         $repl->suspendInput();
+    } else {
+        $screen->addChild($repl);
     }
     $console->addComponent($screen);
     if ($dynamicDisplay) {
@@ -391,11 +392,19 @@ $memoryAdapter = new SynthetiqMemoryAdapter($workingMemory, new Profile('system'
 
 $navigator = null;
 if (!$batchMode) {
-    $console->output('Loading W.I.S.E...', 'system');
+    if ($dynamicDisplay && $statusLine) {
+        $statusLine->setContent('Loading W.I.S.E...');
+    } else {
+        $console->output('Loading W.I.S.E...', 'system');
+    }
     $console->display();
 }
 
-if (!$batchMode || getenv('WISE_NAV_BOOT') === '1') {
+$navBoot = getenv('WISE_NAV_BOOT');
+$bootNavigator = $navBoot === false
+    ? !$batchMode
+    : filter_var($navBoot, FILTER_VALIDATE_BOOLEAN);
+if ($bootNavigator) {
     try {
         $navigator = SynthetiqBootstrap::fromVendorSampleConfigs(null, null, $memoryAdapter, $bootProgress);
     } catch (\Throwable $e) {
@@ -452,6 +461,8 @@ if ($bootProgress) {
 }
 $kernel->boot();
 if (!$batchMode && $statusLine && $screen && $repl) {
+    $repl->setConsole($console);
+    $screen->addChild($repl);
     $statusLine->setContent('');
     $screen->removeChild($statusLine);
     $repl->resumeInput();


### PR DESCRIPTION
## Intent

Keep visual boot visible and ANSI-clean by mounting only the status surface during training, then mounting the REPL once before splash/ready output. Honor explicit `--nav-boot=0` for deterministic UI validation and environments that do not want navigator startup.

## Evidence

- Focused CLI suite: 13 tests, 26 assertions.
- Ubuntu/WSL real PTY: splash and ready state remained visible; `help` executed; `li` + Tab expanded to `list`; `exit` terminated cleanly; no bare `0m`, string-offset warning, or filesystem fatal occurred.
- PowerShell real ConPTY: startup, progress, splash, and ready state render without bare ANSI fragments. Input remains blocked in the existing Windows `ExtendedStdio` boundary, so issue #60 intentionally remains open.

## QA

Run `php vendor/bin/phpunit --do-not-cache-result tests/Cli/ReplKeyInputTest.php tests/Cli/SplashScreenTest.php tests/Cli/TerminalScriptInteractionTest.php tests/ConsoleDisplayUtilTest.php`.

## Approval

CI must pass PHP 8.2/8.3. Land after PR #59. This PR advances but does not close #60.