### PR TITLE
Refresh released intelligence dependency baselines

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.2",
-        "bluefission/develation": "^1.3.43",
-        "bluefission/automata": "^1.0.0-alpha.4",
+        "bluefission/develation": "^1.3.44",
+        "bluefission/automata": "^1.0.0-alpha.5",
         "bluefission/simpleclients": "^0.1.0-alpha",
         "bluefission/synthetiq": "^0.1.0-alpha.1",
         "bluefission/presence": "^0.1.0-alpha.1",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.2",
-        "bluefission/develation": "^1.3.44",
+        "bluefission/develation": "~1.3.43.0",
         "bluefission/automata": "^1.0.0-alpha.5",
         "bluefission/simpleclients": "^0.1.0-alpha",
         "bluefission/synthetiq": "^0.1.0-alpha.1",

--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,11 @@
     "require": {
         "php": ">=8.2",
         "bluefission/develation": "^1.3.43",
-        "bluefission/automata": "^1.0.0-alpha.2",
+        "bluefission/automata": "^1.0.0-alpha.4",
         "bluefission/simpleclients": "^0.1.0-alpha",
         "bluefission/synthetiq": "^0.1.0-alpha.1",
         "bluefission/presence": "^0.1.0-alpha.1",
-        "bluefission/jenerator": "dev-main",
+        "bluefission/jenerator": "^0.1.0-alpha.1",
         "bluefission/vibrato": "dev-main",
         "google/cloud-language": "^0.27.0",
         "orhanerday/open-ai": "^2.2"

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -6,7 +6,7 @@ has no consumable release.
 
 The current intelligence baseline is:
 
-- `bluefission/automata:^1.0.0-alpha.4`, distributed through Packagist.
+- `bluefission/automata:^1.0.0-alpha.5`, distributed through Packagist.
 - `bluefission/jenerator:^0.1.0-alpha.1`, distributed as a tagged private GitHub
   VCS release.
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,20 @@
+# Dependency baselines
+
+Wise consumes reviewed releases for runtime dependencies whenever a release is
+available. Development constraints are retained only while an upstream package
+has no consumable release.
+
+The current intelligence baseline is:
+
+- `bluefission/automata:^1.0.0-alpha.4`, distributed through Packagist.
+- `bluefission/jenerator:^0.1.0-alpha.1`, distributed as a tagged private GitHub
+  VCS release.
+
+The Jenerator repository entry remains necessary for Composer discovery because
+the package is not registered on Packagist. Consumers must authenticate Composer
+for private GitHub access. Moving from `dev-main` to the tagged Jenerator release
+does not change Wise's JenSS bridge API; it makes installs reproducible at the
+reviewed release commit.
+
+`bluefission/vibrato` remains on its existing development constraint until a
+tagged release exposes the Vibe interpreter contract currently consumed by Wise.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -6,6 +6,9 @@ has no consumable release.
 
 The current intelligence baseline is:
 
+- `bluefission/develation:~1.3.43.0`, held below `v1.3.44` until the released
+  BlueCore engine signature is compatible with the newer application singleton
+  contract.
 - `bluefission/automata:^1.0.0-alpha.5`, distributed through Packagist.
 - `bluefission/jenerator:^0.1.0-alpha.1`, distributed as a tagged private GitHub
   VCS release.


### PR DESCRIPTION
## Intent

Move the intelligence runtime onto reviewed prerelease baselines and remove the
remaining Jenerator development requirement while preserving a compatible
DevElation/BlueCore solve.

## User stories / acceptance criteria

- [x] Require Automata `^1.0.0-alpha.5`.
- [x] Require Jenerator `^0.1.0-alpha.1` instead of `dev-main`.
- [x] Retain Jenerator VCS discovery while it is unavailable on Packagist.
- [x] Constrain DevElation to `~1.3.43.0` until a released BlueCore version
      supports the DevElation 1.3.44 application singleton signature.
- [x] Document the exact dependency policy and remaining Vibrato release gate.
- [x] Validate Composer metadata, platform requirements, and advisories.
- [x] Run focused intelligence/CLI tests and the full suite.

## Key files changed

- `composer.json`
- `docs/dependencies.md`

## How to test

```console
composer validate --strict
composer check-platform-reqs
composer audit --locked --no-interaction
vendor/bin/phpunit --do-not-cache-result tests/AutomataOrchestratorTest.php tests/IO/JenssStressScriptTest.php tests/IO/JenssBridgePipelineTest.php tests/Cli/TerminalScriptInteractionTest.php tests/Examples/ExampleBridgeSmokeTest.php
vendor/bin/phpunit --do-not-cache-result
php terminal.php --input-file=examples/batch-commands.txt --display-mode=static --output-mode=console --nav-boot=0
php examples/headless-command.php
```

Focused proof: 60 tests, 137 assertions.

Full proof: 254 tests, 773 assertions, one expected optional integration skip.

The solve resolves Automata `v1.0.0-alpha.5` at `b3e3e1e7` and Jenerator
`v0.1.0-alpha.1` at `1104094`.

## QA checklist

- [x] Composer validation passes.
- [x] PHP 8.2 platform requirements pass.
- [x] Composer reports no security advisories.
- [x] Static batch and headless examples pass.
- [x] PHP 8.2 and PHP 8.3 CI pass.
- [x] No secrets or environment configuration changed.

## Approval conditions

- PHP 8.2 and PHP 8.3 CI pass.
- Analysis passes.
- No unresolved review comments remain.
- Merge exact reviewed head only.

Closes #62
