### PR TITLE
Prepare first immutable alpha release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,161 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    env:
+      GH_REPO_TOKEN: ${{ secrets.BF_GITHUB_TOKEN != '' && secrets.BF_GITHUB_TOKEN || secrets.CI_GITHUB_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+          - '8.2'
+          - '8.3'
+
+    steps:
+      - name: Check out immutable tag
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Sanitize GitHub authentication
+        run: |
+          git config --local --unset-all http.https://github.com/.extraheader || true
+          git config --local --unset-all credential.helper || true
+          git config --global --unset-all http.https://github.com/.extraheader || true
+          git config --global --unset-all credential.helper || true
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: composer:v2
+
+      - name: Validate release identity
+        shell: bash
+        run: |
+          [[ "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$ ]]
+          php -r "require 'src/Wise/Version.php'; exit('v' . BlueFission\\Wise\\Version::CURRENT === getenv('GITHUB_REF_NAME') ? 0 : 1);"
+
+      - name: Validate Composer manifest
+        run: composer validate --strict --no-check-lock
+
+      - name: Check private dependency access
+        run: |
+          if [ -z "${GH_REPO_TOKEN:-}" ]; then
+            echo "::error::Set BF_GITHUB_TOKEN or CI_GITHUB_TOKEN so Composer can install private dependencies."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: |
+          export COMPOSER_AUTH="{\"github-oauth\":{\"github.com\":\"${GH_REPO_TOKEN}\"}}"
+          composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Verify authoritative PSR-4 autoloading
+        run: composer dump-autoload --classmap-authoritative --strict-psr
+
+      - name: Check platform requirements
+        run: composer check-platform-reqs
+
+      - name: Audit dependencies
+        run: composer audit
+
+      - name: Run test suite
+        run: vendor/bin/phpunit --do-not-cache-result
+
+  clean-consumer:
+    name: Clean consumer PHP ${{ matrix.php }}
+    needs: verify
+    runs-on: ubuntu-latest
+    env:
+      GH_REPO_TOKEN: ${{ secrets.BF_GITHUB_TOKEN != '' && secrets.BF_GITHUB_TOKEN || secrets.CI_GITHUB_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+          - '8.2'
+          - '8.3'
+
+    steps:
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: composer:v2
+
+      - name: Install immutable release from VCS
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+          RELEASE_VERSION: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          if [ -z "${GH_REPO_TOKEN:-}" ]; then
+            echo "::error::Set BF_GITHUB_TOKEN or CI_GITHUB_TOKEN so Composer can install private dependencies."
+            exit 1
+          fi
+
+          export COMPOSER_AUTH="{\"github-oauth\":{\"github.com\":\"${GH_REPO_TOKEN}\"}}"
+          composer init --name=bluefission/wise-consumer --no-interaction
+          composer config minimum-stability dev
+          composer config prefer-stable true
+          composer config repositories.wise vcs https://github.com/BlueFissionTech/wise.git
+          composer config repositories.jenerator vcs https://github.com/BlueFissionTech/jenerator.git
+          composer config repositories.vibrato vcs https://github.com/BlueFissionTech/vibrato.git
+          composer config repositories.presence vcs https://github.com/BlueFissionTech/presence.git
+          composer require "bluefission/wise:${RELEASE_VERSION#v}" --prefer-dist --no-interaction --no-progress
+          php -r "require 'vendor/autoload.php'; exit(class_exists('BlueFission\\Wise\\Version') && interface_exists('BlueFission\\Wise\\Cmd\\ICommandProcessor') && class_exists('BlueFission\\Wise\\Usr\\Auth\\PresenceIdentityBridge') ? 0 : 1);"
+          php -r '$lock = json_decode(file_get_contents("composer.lock"), true, 512, JSON_THROW_ON_ERROR); foreach ($lock["packages"] as $package) { if ($package["name"] === "bluefission/wise") { exit(($package["source"]["reference"] ?? null) === getenv("EXPECTED_SHA") ? 0 : 1); } } exit(1);'
+
+  publish:
+    name: Publish GitHub prerelease
+    needs:
+      - verify
+      - clean-consumer
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out immutable tag
+        uses: actions/checkout@v5
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer:v2
+
+      - name: Build package archive
+        run: composer archive --format=zip --dir=dist
+
+      - name: Upload package archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: wise-${{ github.ref_name }}
+          path: dist/*.zip
+
+      - name: Create prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          gh release create "$GITHUB_REF_NAME" dist/*.zip \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Wise $GITHUB_REF_NAME" \
+            --prerelease \
+            --generate-notes \
+            --verify-tag

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -21,3 +21,28 @@ reviewed release commit.
 
 `bluefission/vibrato` remains on its existing development constraint until a
 tagged release exposes the Vibe interpreter contract currently consumed by Wise.
+
+## Consumer installation
+
+Composer only reads repository declarations from the root package. Consumers
+of the tagged Wise alpha must therefore declare the Wise, Jenerator, Vibrato,
+and Presence GitHub VCS repositories themselves and authenticate Composer with
+a read-only GitHub token. Because Vibrato remains on `dev-main`, the consumer
+root must permit development stability while keeping `prefer-stable` enabled.
+
+```bash
+composer config minimum-stability dev
+composer config prefer-stable true
+composer config repositories.wise vcs https://github.com/BlueFissionTech/wise.git
+composer config repositories.jenerator vcs https://github.com/BlueFissionTech/jenerator.git
+composer config repositories.vibrato vcs https://github.com/BlueFissionTech/vibrato.git
+composer config repositories.presence vcs https://github.com/BlueFissionTech/presence.git
+composer require bluefission/wise:0.1.0-alpha.1
+```
+
+Supply GitHub authentication through `COMPOSER_AUTH` or Composer's local auth
+configuration. Never commit a token to the consuming project.
+
+The release workflow installs each tag into an empty consumer project on PHP
+8.2 and 8.3, checks the public command and authentication contracts, and proves
+that Composer resolved `bluefission/wise` to the exact tagged source commit.

--- a/src/Wise/Cli/Components/SplashScreen.php
+++ b/src/Wise/Cli/Components/SplashScreen.php
@@ -3,6 +3,7 @@
 namespace BlueFission\Wise\Cli\Components;
 
 use BlueFission\Arr;
+use BlueFission\Wise\Version;
 
 class SplashScreen extends Component
 {
@@ -100,9 +101,11 @@ class SplashScreen extends Component
         $content .= PHP_EOL . "            ";
         $content .= "Workspace Intelligence Shell Environment";
         $content .= PHP_EOL . PHP_EOL;
-        $content .= "Running WISE version 0.0.1, produced by Blue Fission.";
+        $content .= 'Running WISE version ' . Version::CURRENT . ', produced by Blue Fission.';
         $content .= PHP_EOL;
-        $content .= "Jen interpreter running version 0.0.1." . PHP_EOL . PHP_EOL;
+        $content .= 'Jen interpreter running version '
+            . Version::package('bluefission/jenerator')
+            . '.' . PHP_EOL . PHP_EOL;
 
         $this->setContent($content);
     }

--- a/src/Wise/Version.php
+++ b/src/Wise/Version.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace BlueFission\Wise;
+
+use Composer\InstalledVersions;
+
+final class Version
+{
+    public const CURRENT = '0.1.0-alpha.1';
+
+    private function __construct()
+    {
+    }
+
+    public static function package(string $package): string
+    {
+        if (!InstalledVersions::isInstalled($package)) {
+            return 'unavailable';
+        }
+
+        return InstalledVersions::getPrettyVersion($package)
+            ?? InstalledVersions::getVersion($package)
+            ?? 'unknown';
+    }
+}

--- a/tests/Cli/SplashScreenTest.php
+++ b/tests/Cli/SplashScreenTest.php
@@ -3,10 +3,33 @@
 namespace BlueFission\Tests\Cli;
 
 use BlueFission\Wise\Cli\Components\SplashScreen;
+use BlueFission\Wise\Version;
 use PHPUnit\Framework\TestCase;
 
 final class SplashScreenTest extends TestCase
 {
+    public function testSplashReportsReleasedPackageVersions(): void
+    {
+        $previousGlitch = getenv('WISE_SPLASH_GLITCH');
+        putenv('WISE_SPLASH_GLITCH=0');
+
+        try {
+            $content = implode(PHP_EOL, (new SplashScreen())->draw());
+        } finally {
+            putenv(
+                $previousGlitch === false
+                    ? 'WISE_SPLASH_GLITCH'
+                    : 'WISE_SPLASH_GLITCH=' . $previousGlitch
+            );
+        }
+
+        $this->assertStringContainsString('WISE version ' . Version::CURRENT, $content);
+        $this->assertStringContainsString(
+            'Jen interpreter running version ' . Version::package('bluefission/jenerator'),
+            $content
+        );
+    }
+
     public function testGlitchSplashKeepsLogoContent(): void
     {
         $previous = getenv('WISE_SPLASH_GLITCH');


### PR DESCRIPTION
## Intent

Prepare Wise for its first immutable alpha release with a single package version authority, authenticated tag verification, and exact-source clean-consumer proof.

## User stories and acceptance criteria

- A package consumer can install a reviewed SemVer alpha instead of tracking a development branch.
- The CLI reports the same Wise version encoded by the release tag.
- Tag CI validates Composer metadata, authoritative PSR-4 loading, platform requirements, dependency advisories, and the complete suite on PHP 8.2 and 8.3.
- An empty authenticated consumer project installs the exact tag with the required private VCS roots and proves the resolved source SHA.
- A GitHub prerelease and package archive are published only after all verification jobs pass.

## Key files

- `.github/workflows/release.yml`: immutable tag, clean-consumer, archive, and prerelease workflow.
- `src/Wise/Version.php`: authoritative package version and installed dependency version lookup.
- `src/Wise/Cli/Components/SplashScreen.php`: accurate package and Jenerator version output.
- `docs/dependencies.md`: root Composer repository and authentication contract.
- `tests/Cli/SplashScreenTest.php`: version-output regression coverage.

## How to test

```bash
composer validate --strict --no-check-lock
composer dump-autoload --classmap-authoritative --strict-psr
composer check-platform-reqs
vendor/bin/phpunit --do-not-cache-result tests/Cli/SplashScreenTest.php
vendor/bin/phpunit --do-not-cache-result
```

Local PHP 8.2 result: 265 tests, 833 assertions, one expected skip.

## QA checklist

- [x] Version source and planned tag are identical.
- [x] Private dependency tokens are referenced only through Actions secrets.
- [x] Consumer repository declarations are explicit because Composer does not inherit dependency repositories.
- [x] The release workflow verifies the exact Wise source SHA.
- [x] No host or command-processing API changes.

## Approval conditions

Merge after PHP 8.2, PHP 8.3, and analysis checks pass. Publish `v0.1.0-alpha.1` only from the exact reviewed merge commit, then require the tag workflow and clean-consumer matrix to pass before announcing the release.

Closes #66
