### PR TITLE
Complete alpha clean-consumer policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,9 @@ jobs:
           composer config repositories.jenerator vcs https://github.com/BlueFissionTech/jenerator.git
           composer config repositories.vibrato vcs https://github.com/BlueFissionTech/vibrato.git
           composer config repositories.presence vcs https://github.com/BlueFissionTech/presence.git
+          composer config --no-plugins allow-plugins.composer/installers true
+          composer config --no-plugins allow-plugins.php-http/discovery true
+          composer config --no-plugins allow-plugins.bluefission/bluecore true
           composer require "bluefission/wise:${RELEASE_VERSION#v}" --prefer-dist --no-interaction --no-progress
           php -r "require 'vendor/autoload.php'; exit(class_exists('BlueFission\\Wise\\Version') && interface_exists('BlueFission\\Wise\\Cmd\\ICommandProcessor') && class_exists('BlueFission\\Wise\\Usr\\Auth\\PresenceIdentityBridge') ? 0 : 1);"
           php -r '$lock = json_decode(file_get_contents("composer.lock"), true, 512, JSON_THROW_ON_ERROR); foreach ($lock["packages"] as $package) { if ($package["name"] === "bluefission/wise") { exit(($package["source"]["reference"] ?? null) === getenv("EXPECTED_SHA") ? 0 : 1); } } exit(1);'

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -37,7 +37,10 @@ composer config repositories.wise vcs https://github.com/BlueFissionTech/wise.gi
 composer config repositories.jenerator vcs https://github.com/BlueFissionTech/jenerator.git
 composer config repositories.vibrato vcs https://github.com/BlueFissionTech/vibrato.git
 composer config repositories.presence vcs https://github.com/BlueFissionTech/presence.git
-composer require bluefission/wise:0.1.0-alpha.1
+composer config --no-plugins allow-plugins.composer/installers true
+composer config --no-plugins allow-plugins.php-http/discovery true
+composer config --no-plugins allow-plugins.bluefission/bluecore true
+composer require bluefission/wise:0.1.0-alpha.2
 ```
 
 Supply GitHub authentication through `COMPOSER_AUTH` or Composer's local auth

--- a/src/Wise/Version.php
+++ b/src/Wise/Version.php
@@ -6,7 +6,7 @@ use Composer\InstalledVersions;
 
 final class Version
 {
-    public const CURRENT = '0.1.0-alpha.1';
+    public const CURRENT = '0.1.0-alpha.2';
 
     private function __construct()
     {


### PR DESCRIPTION
## Intent

Complete the immutable alpha release gate after the first tag proved that Composer root projects must explicitly authorize trusted plugins.

## Acceptance criteria

- Advance the package version to 0.1.0-alpha.2 without rewriting alpha.1.
- Configure composer/installers, php-http/discovery, and bluefission/bluecore in the empty consumer before installation.
- Document the same root policy for package consumers.
- Preserve exact-source SHA verification on PHP 8.2 and 8.3.

## Key files

- .github/workflows/release.yml
- src/Wise/Version.php
- docs/dependencies.md

## How to test

composer validate --strict --no-check-lock
vendor/bin/phpunit --do-not-cache-result tests/Cli/SplashScreenTest.php
vendor/bin/phpunit --do-not-cache-result

Local result: 265 tests, 833 assertions, one expected skip.

## QA checklist

- [x] alpha.1 remains immutable.
- [x] plugin trust is explicit at the consumer root.
- [x] no runtime API changes.
- [x] version identity matches planned alpha.2 tag.

## Approval conditions

Merge after PHP 8.2, PHP 8.3, and analysis pass. Publish v0.1.0-alpha.2 only from the reviewed merge and announce it only after the full tag workflow succeeds.

Closes #66