### PR TITLE
Document VCS-only alpha distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
           php -r '$lock = json_decode(file_get_contents("composer.lock"), true, 512, JSON_THROW_ON_ERROR); foreach ($lock["packages"] as $package) { if ($package["name"] === "bluefission/wise") { exit(($package["source"]["reference"] ?? null) === getenv("EXPECTED_SHA") ? 0 : 1); } } exit(1);'
 
   publish:
-    name: Publish GitHub prerelease
+    name: Publish GitHub VCS prerelease
     needs:
       - verify
       - clean-consumer

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -4,6 +4,14 @@ Wise consumes reviewed releases for runtime dependencies whenever a release is
 available. Development constraints are retained only while an upstream package
 has no consumable release.
 
+Wise alpha releases are distributed exclusively through immutable GitHub VCS
+tags and prerelease archives. The release workflow verifies package and empty
+consumer installs on PHP 8.2 and 8.3, but it does not publish Wise to
+Packagist. Registry publication is deferred until the required interpreter and
+authentication dependency graph has reviewed registry releases. Consumers must
+therefore use the VCS configuration below rather than expect Composer registry
+discovery for `bluefission/wise`.
+
 The current intelligence baseline is:
 
 - `bluefission/develation:~1.3.43.0`, held below `v1.3.44` until the released
@@ -46,6 +54,8 @@ composer require bluefission/wise:0.1.0-alpha.2
 Supply GitHub authentication through `COMPOSER_AUTH` or Composer's local auth
 configuration. Never commit a token to the consuming project.
 
-The release workflow installs each tag into an empty consumer project on PHP
-8.2 and 8.3, checks the public command and authentication contracts, and proves
-that Composer resolved `bluefission/wise` to the exact tagged source commit.
+The release workflow installs each VCS tag into an empty consumer project on
+PHP 8.2 and 8.3, checks the public command and authentication contracts, proves
+that Composer resolved `bluefission/wise` to the exact tagged source commit,
+and publishes a GitHub prerelease archive. It has no Packagist publication
+step.

--- a/tests/ReleaseDistributionTest.php
+++ b/tests/ReleaseDistributionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace BlueFission\Tests;
+
+use BlueFission\Str;
+use BlueFission\Wise\Sys\FileSystemManager;
+use PHPUnit\Framework\TestCase;
+
+final class ReleaseDistributionTest extends TestCase
+{
+    public function testReleaseWorkflowPublishesOnlyGithubVcsRelease(): void
+    {
+        $path = dirname(__DIR__) . DIRECTORY_SEPARATOR . '.github'
+            . DIRECTORY_SEPARATOR . 'workflows' . DIRECTORY_SEPARATOR . 'release.yml';
+        $contents = FileSystemManager::readPath($path);
+
+        $this->assertIsString($contents);
+
+        $workflow = Str::lower($contents);
+
+        $this->assertTrue(Str::has($workflow, 'name: publish github vcs prerelease'));
+        $this->assertTrue(Str::has($workflow, 'gh release create'));
+        $this->assertTrue(Str::has($workflow, 'composer config repositories.wise vcs'));
+        $this->assertFalse(Str::has($workflow, 'packagist'));
+    }
+}


### PR DESCRIPTION
## Intent

Make authenticated GitHub VCS the explicit distribution contract for Wise alpha releases.

Closes #69.

## User stories / acceptance criteria

- Consumers can identify the supported VCS installation path without expecting a Packagist package.
- The dependency guide explains why registry publication is deferred.
- The release workflow remains limited to immutable GitHub prereleases and VCS clean-consumer proof.
- Regression coverage rejects an accidental Packagist publication step.
- PHP 8.2 and 8.3 release behavior remains unchanged.

## Key files changed

- `.github/workflows/release.yml`: names the publication job as the GitHub VCS prerelease.
- `docs/dependencies.md`: documents VCS-only distribution and root Composer requirements.
- `tests/ReleaseDistributionTest.php`: enforces the distribution boundary.

## How to test

```bash
php -l tests/ReleaseDistributionTest.php
vendor/bin/phpunit --do-not-cache-result tests/ReleaseDistributionTest.php
vendor/bin/phpunit --do-not-cache-result
composer validate --strict --no-check-lock
git diff --check
```

Focused proof: 1 test, 5 assertions.
Full proof: 266 tests, 838 assertions, one expected skip.
Composer metadata is valid; the existing lock warning remains unrelated to this documentation/workflow change.

## QA checklist

- [x] No Packagist submission or registry mutation occurred.
- [x] Release workflow still publishes only a GitHub prerelease archive.
- [x] Empty-consumer VCS checks remain present for PHP 8.2 and 8.3.
- [x] Documentation includes all required root VCS repositories and plugin authorization.
- [x] Full local suite passes.

## Approval conditions

Approve when the VCS-only distribution contract and regression guard match the intended alpha release policy.
